### PR TITLE
Add additional arguments settings and launch cmd preview

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ class SettingsManager(object):
 			'dvd_path': '/path/to/disc.iso',
 			'short_anim': False,
 			'sys_memory': '64 MiB',
+			'extra_args': '',
 		}
 
 	def save(self):
@@ -90,6 +91,7 @@ class SettingsWindow(QDialog, settings_class):
 		bindFilePicker(self.setHddPath, self.hddPath)
 		bindCheckWidget(self.hddLocked, 'hdd_locked')
 		bindDropdownWidget(self.systemMemory, 'sys_memory')
+		bindTextWidget(self.additionalArgs, 'extra_args')
 
 	def setSaveFileName(self, obj):
 		options = QFileDialog.Options()
@@ -127,6 +129,8 @@ class Xqemu(object):
 			check_path(settings.settings['dvd_path'])
 			dvd_path_arg = ',file=' + settings.settings['dvd_path']
 
+		extra_args = [x for x in settings.settings['extra_args'].split(' ') if x is not '']
+
 		# Build qemu lunch cmd
 		cmd = [xqemu_path,
 		       '-cpu','pentium3',
@@ -138,7 +142,7 @@ class Xqemu(object):
 		       '-drive','file=%(hdd_path)s,index=0,media=disk%(hdd_lock_arg)s' % locals(),
 		       '-drive','index=1,media=cdrom%(dvd_path_arg)s' % locals(),
 		       '-qmp','tcp:localhost:4444,server,nowait',
-		       '-display','sdl']
+		       '-display','sdl'] + extra_args
 
 		# Attempt to interpret the constructed command line
 		cmd_escaped = []

--- a/settings.ui
+++ b/settings.ui
@@ -468,6 +468,41 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="cliTab">
+      <attribute name="title">
+       <string>CLI</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_8">
+       <item>
+        <widget class="QGroupBox" name="groupBox_10">
+         <property name="title">
+          <string>Additonal arguments</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_7">
+          <item row="0" column="0">
+           <widget class="QLineEdit" name="additionalArgs"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_9">
+         <property name="title">
+          <string>XQEMU invocation preview</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_6">
+          <item row="0" column="0">
+           <widget class="QPlainTextEdit" name="invocationPreview">
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="aboutTab">
       <attribute name="title">
        <string>About</string>


### PR DESCRIPTION
The first commit contains the UI changes and adds a text field with which additional arguments to xqemu can be provided.
The second commit hooks up the second text field to provide a live preview of the launch command (and also splits up the launch cmd generation into static methods to accomplish that).

If these changes are fine this should resolve #9 and #10.