### PR TITLE
Add support for memory units

### DIFF
--- a/main.py
+++ b/main.py
@@ -149,7 +149,7 @@ class Xqemu(object):
 			 'Gamepad #2': 'usb-xbox-gamepad-sdl,index=2',
 			 'Gamepad #3': 'usb-xbox-gamepad-sdl,index=3'}.get(settings.settings[name], '')
 			if arg is not '':
-				return ['-device'] + [arg + ',port=' + str(port)]
+				return ['-device'] + [arg + ',port=' + str(port) + ".1"]
 			return []
 
 		args = []
@@ -200,6 +200,10 @@ class Xqemu(object):
 		       '-net','user',
 		       '-drive','file=%(hdd_path_arg)s,index=0,media=disk%(hdd_lock_arg)s' % locals(),
 		       '-drive','index=1,media=cdrom%(dvd_path_arg)s' % locals(),
+		       '-usb', '-device', 'usb-hub,port=3',
+		       '-usb', '-device', 'usb-hub,port=4',
+		       '-usb', '-device', 'usb-hub,port=1',
+		       '-usb', '-device', 'usb-hub,port=2',
 		       '-qmp','tcp:localhost:4444,server,nowait',
 		       '-display','sdl']
 

--- a/settings.ui
+++ b/settings.ui
@@ -383,42 +383,101 @@
        <item row="0" column="1">
         <widget class="QGroupBox" name="controller2Box">
          <property name="title">
-          <string>Controller 2</string>
+          <string>Port 2</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_17">
           <item>
-           <widget class="QComboBox" name="controller2">
-            <item>
-             <property name="text">
-              <string>Not connected</string>
-             </property>
+           <layout class="QGridLayout" name="gridLayout_9">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_14">
+              <property name="text">
+               <string>Controller:</string>
+              </property>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Keyboard</string>
-             </property>
+            <item row="1" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_10">
+              <item>
+               <widget class="QLineEdit" name="xmu2APath"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu2A">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #0</string>
-             </property>
+            <item row="2" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_12">
+              <item>
+               <widget class="QLineEdit" name="xmu2BPath"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu2B">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #1</string>
-             </property>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_19">
+              <property name="text">
+               <string>Memory Unit A:</string>
+              </property>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #2</string>
-             </property>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="controller2">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <item>
+               <property name="text">
+                <string>Not connected</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Keyboard</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #0</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #1</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #2</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #3</string>
+               </property>
+              </item>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #3</string>
-             </property>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_22">
+              <property name="text">
+               <string>Memory Unit B:</string>
+              </property>
+             </widget>
             </item>
-           </widget>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -426,42 +485,101 @@
        <item row="2" column="0">
         <widget class="QGroupBox" name="controller3Box">
          <property name="title">
-          <string>Controller 3</string>
+          <string>Port 3</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_18">
           <item>
-           <widget class="QComboBox" name="controller3">
-            <item>
-             <property name="text">
-              <string>Not connected</string>
-             </property>
+           <layout class="QGridLayout" name="gridLayout_10">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_15">
+              <property name="text">
+               <string>Controller:</string>
+              </property>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Keyboard</string>
-             </property>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="controller3">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <item>
+               <property name="text">
+                <string>Not connected</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Keyboard</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #0</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #1</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #2</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #3</string>
+               </property>
+              </item>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #0</string>
-             </property>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_20">
+              <property name="text">
+               <string>Memory Unit A:</string>
+              </property>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #1</string>
-             </property>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_23">
+              <property name="text">
+               <string>Memory Unit B:</string>
+              </property>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #2</string>
-             </property>
+            <item row="1" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_13">
+              <item>
+               <widget class="QLineEdit" name="xmu3APath"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu3A">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #3</string>
-             </property>
+            <item row="2" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_14">
+              <item>
+               <widget class="QLineEdit" name="xmu3BPath"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu3B">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
-           </widget>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -469,42 +587,101 @@
        <item row="2" column="1">
         <widget class="QGroupBox" name="controller4Box">
          <property name="title">
-          <string>Controller 4</string>
+          <string>Port 4</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_19">
           <item>
-           <widget class="QComboBox" name="controller4">
-            <item>
-             <property name="text">
-              <string>Not connected</string>
-             </property>
+           <layout class="QGridLayout" name="gridLayout_11">
+            <item row="0" column="1">
+             <widget class="QComboBox" name="controller4">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <item>
+               <property name="text">
+                <string>Not connected</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Keyboard</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #0</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #1</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #2</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #3</string>
+               </property>
+              </item>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Keyboard</string>
-             </property>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_21">
+              <property name="text">
+               <string>Memory Unit A:</string>
+              </property>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #0</string>
-             </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_16">
+              <property name="text">
+               <string>Controller:</string>
+              </property>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #1</string>
-             </property>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_24">
+              <property name="text">
+               <string>Memory Unit B:</string>
+              </property>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #2</string>
-             </property>
+            <item row="1" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_15">
+              <item>
+               <widget class="QLineEdit" name="xmu4APath"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu4A">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #3</string>
-             </property>
+            <item row="2" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_16">
+              <item>
+               <widget class="QLineEdit" name="xmu4BPath"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu4B">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
-           </widget>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -512,42 +689,107 @@
        <item row="0" column="0">
         <widget class="QGroupBox" name="controller1Box">
          <property name="title">
-          <string>Controller 1</string>
+          <string>Port 1</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_16">
           <item>
-           <widget class="QComboBox" name="controller1">
-            <item>
-             <property name="text">
-              <string>Not connected</string>
-             </property>
+           <layout class="QGridLayout" name="gridLayout_3">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_13">
+              <property name="text">
+               <string>Controller:</string>
+              </property>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Keyboard</string>
-             </property>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_17">
+              <property name="text">
+               <string>Memory Unit A:</string>
+              </property>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #0</string>
-             </property>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="controller1">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <item>
+               <property name="text">
+                <string>Not connected</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Keyboard</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #0</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #1</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #2</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #3</string>
+               </property>
+              </item>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #1</string>
-             </property>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_18">
+              <property name="text">
+               <string>Memory Unit B:</string>
+              </property>
+             </widget>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #2</string>
-             </property>
+            <item row="1" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_9">
+              <item>
+               <widget class="QLineEdit" name="xmu1APath"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu1A">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
-            <item>
-             <property name="text">
-              <string>Gamepad #3</string>
-             </property>
+            <item row="2" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_11">
+              <item>
+               <widget class="QLineEdit" name="xmu1BPath"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu1B">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
-           </widget>
+           </layout>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
This adds support for configuring memory units via xqemu-manager.
The first commit introduces USB hubs instead of connecting the virtual controllers directly, the second one adds support for two memory units per port.
The changes were tested with 8 MiB qcow2 images.

Screenshots demonstrating how it looks like and that it works:
![2018-12-24-022147_660x352_scrot](https://user-images.githubusercontent.com/1339483/50388914-150e0180-0723-11e9-9c49-14760b79d2f4.png)
![screenshot_20181224_020456](https://user-images.githubusercontent.com/1339483/50388918-1b03e280-0723-11e9-8918-8294d243d748.png)
![screenshot_20181224_020509](https://user-images.githubusercontent.com/1339483/50388922-25be7780-0723-11e9-9c34-b42dab9547cd.png)
![screenshot_20181224_020542](https://user-images.githubusercontent.com/1339483/50388924-366eed80-0723-11e9-95d7-4c1306ea52e1.png)
