### PR TITLE
Minimize args and disable using MUs in ports without attached controllers

### DIFF
--- a/main.py
+++ b/main.py
@@ -173,7 +173,7 @@ class Xqemu(object):
 			 'Gamepad #2': 'usb-xbox-gamepad-sdl,index=2',
 			 'Gamepad #3': 'usb-xbox-gamepad-sdl,index=3'}.get(settings.settings[name], '')
 			if arg is not '':
-				return ['-device'] + [arg + ',port=' + str(port) + ".1"]
+				return ['-device', 'usb-hub,port=' + str(port), '-device'] + [arg + ',port=' + str(port) + ".1"]
 			return []
 
 		args = []
@@ -192,10 +192,11 @@ class Xqemu(object):
 			return path.replace(',', ',,')
 
 		def genArg(settings, name, port):
-			if settings.settings[name] is not '':
+			port_arr = ['controller_three', 'controller_four', 'controller_one', 'controller_two']
+			if settings.settings[name] is not '' and settings.settings[port_arr[int(port[:1]) - 1]] != 'Not connected':
 				check_path(settings.settings[name])
 				return ['-drive', 'if=none,id=' + name + ',file=' + escape_path(settings.settings[name]),
-				        '-device', 'usb-storage,drive=' + name + ',port=' + port]
+						'-device', 'usb-storage,drive=' + name + ',port=' + port]
 			return []
 
 		args = []
@@ -243,14 +244,8 @@ class Xqemu(object):
 		       '-machine','xbox%(accelerator_arg)s,bootrom=%(mcpx_path_arg)s%(short_anim_arg)s' % locals(),
 		       '-m', '%(sys_memory)s' % locals(),
 		       '-bios', '%(flash_path_arg)s' % locals(),
-		       '-net','nic,model=nvnet',
-		       '-net','user',
 		       '-drive','file=%(hdd_path_arg)s,index=0,media=disk%(hdd_lock_arg)s' % locals(),
 		       '-drive','index=1,media=cdrom%(dvd_path_arg)s' % locals(),
-		       '-usb', '-device', 'usb-hub,port=3',
-		       '-usb', '-device', 'usb-hub,port=4',
-		       '-usb', '-device', 'usb-hub,port=1',
-		       '-usb', '-device', 'usb-hub,port=2',
 		       '-qmp','tcp:localhost:4444,server,nowait',
 		       '-display','sdl']
 


### PR DESCRIPTION
As it stands right now there's a few redundant args being set such as `-net nic,model=nvnet`, `-net user`, and `-usb`. All 3 of these are automatically set by default.

In this commit i've removed those as well as made it impossible to attach a MU when a controller isn't present in that particular port (if there's a way to disable the "Choose..." button I think that would be a better solution than what I came up with here).

Default args with controller attached to player 1 --

Original:
`
/path/to/xqemu -cpu pentium3 -machine xbox,bootrom=/path/to/mcpx.bin -m 64M -bios /path/to/flash.bin -net nic,model=nvnet -net user -drive file=/path/to/hdd.img,index=0,media=disk,locked -drive index=1,media=cdrom,file=/path/to/disc.iso -usb -device usb-hub,port=3 -usb -device usb-hub,port=4 -usb -device usb-hub,port=1 -usb -device usb-hub,port=2 -qmp tcp:localhost:4444,server,nowait -display sdl -device usb-xbox-gamepad-sdl,index=0,port=3.1
`

Modified:
`
/path/to/xqemu -cpu pentium3 -machine xbox,bootrom=/path/to/mcpx.bin -m 64M -bios /path/to/flash.bin -drive file=/path/to/hdd.img,index=0,media=disk,locked -drive index=1,media=cdrom,file=/path/to/disc.iso -qmp tcp:localhost:4444,server,nowait -display sdl -device usb-hub,port=3 -device usb-xbox-gamepad-sdl,index=0,port=3.1
`

I'm ok with this not being merged if it's not ideal, but I figured I'd offer it up to discussion.