### PR TITLE
Hide MUs if their respective controllers are "Not connected"

### DIFF
--- a/main.py
+++ b/main.py
@@ -416,6 +416,9 @@ def main():
 	palette.setColor(QtGui.QPalette.BrightText, QtCore.Qt.red)
 	palette.setColor(QtGui.QPalette.Highlight, QtGui.QColor(45,197,45).lighter())
 	palette.setColor(QtGui.QPalette.HighlightedText, QtCore.Qt.black)
+	palette.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.Text, QtCore.Qt.darkGray)
+	palette.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.ButtonText, QtCore.Qt.darkGray)
+	palette.setColor(QtGui.QPalette.Disabled, QtGui.QPalette.WindowText, QtCore.Qt.darkGray)
 	app.setPalette(palette)
 
 	widget = MainWindow()

--- a/main.py
+++ b/main.py
@@ -80,6 +80,14 @@ class SettingsWindow(QDialog, settings_class):
 		def getDropdownAttr(widget, var): widget.setCurrentText(self.settings.settings[var])
 		def updateLaunchCmd(): self.invocationPreview.setPlainText(Xqemu.launchCmdToString(Xqemu.generateLaunchCmd(self.settings, True)))
 
+		def updateControllerUi():
+			# Update all four controllers
+			for i in [1, 2, 3, 4]:
+				controller = getattr(self, 'controller' + str(i))
+				is_connected = (controller.currentIndex() != 0)
+				group = getattr(self, 'controller' + str(i) + 'Additional')
+				group.setEnabled(is_connected)
+
 		def bindTextWidget(widget, var):
 			getTextAttr(widget, var)
 			widget.textChanged.connect(lambda:setTextAttr(widget, var))
@@ -137,7 +145,16 @@ class SettingsWindow(QDialog, settings_class):
 		bindCheckWidget(self.waitForGdb, 'gdb_wait')
 		bindTextWidget(self.gdbPort, 'gdb_port')
 		bindTextWidget(self.additionalArgs, 'extra_args')
+		
+		# Controller UI has additional logic
+		self.controller1.currentIndexChanged.connect(updateControllerUi)
+		self.controller2.currentIndexChanged.connect(updateControllerUi)
+		self.controller3.currentIndexChanged.connect(updateControllerUi)
+		self.controller4.currentIndexChanged.connect(updateControllerUi)
+		
+		# Prepare initial UI state
 		updateLaunchCmd()
+		updateControllerUi()
 
 	def setSaveFileName(self, obj):
 		options = QFileDialog.Options()

--- a/settings.ui
+++ b/settings.ui
@@ -387,50 +387,15 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_17">
           <item>
-           <layout class="QGridLayout" name="gridLayout_9">
-            <item row="0" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
              <widget class="QLabel" name="label_14">
               <property name="text">
                <string>Controller:</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_10">
-              <item>
-               <widget class="QLineEdit" name="xmu2APath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu2A">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="2" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_12">
-              <item>
-               <widget class="QLineEdit" name="xmu2BPath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu2B">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_19">
-              <property name="text">
-               <string>Memory Unit A:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
+            <item>
              <widget class="QComboBox" name="controller2">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -470,14 +435,55 @@
               </item>
              </widget>
             </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_22">
-              <property name="text">
-               <string>Memory Unit B:</string>
-              </property>
-             </widget>
-            </item>
            </layout>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="controller2Additional">
+            <layout class="QVBoxLayout" name="_2">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_10">
+               <item>
+                <widget class="QLabel" name="xmuLabel2A">
+                 <property name="text">
+                  <string>Memory Unit A:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="xmu2APath"/>
+               </item>
+               <item>
+                <widget class="QPushButton" name="setXmu2A">
+                 <property name="text">
+                  <string>Choose...</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_12">
+               <item>
+                <widget class="QLabel" name="xmuLabel2B">
+                 <property name="text">
+                  <string>Memory Unit B:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="xmu2BPath"/>
+               </item>
+               <item>
+                <widget class="QPushButton" name="setXmu2B">
+                 <property name="text">
+                  <string>Choose...</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -489,15 +495,15 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_18">
           <item>
-           <layout class="QGridLayout" name="gridLayout_10">
-            <item row="0" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
              <widget class="QLabel" name="label_15">
               <property name="text">
                <string>Controller:</string>
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
+            <item>
              <widget class="QComboBox" name="controller3">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -537,49 +543,55 @@
               </item>
              </widget>
             </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_20">
-              <property name="text">
-               <string>Memory Unit A:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_23">
-              <property name="text">
-               <string>Memory Unit B:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_13">
-              <item>
-               <widget class="QLineEdit" name="xmu3APath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu3A">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="2" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_14">
-              <item>
-               <widget class="QLineEdit" name="xmu3BPath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu3B">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
            </layout>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="controller3Additional">
+            <layout class="QVBoxLayout" name="_4">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_13">
+               <item>
+                <widget class="QLabel" name="xmuLabel3A">
+                 <property name="text">
+                  <string>Memory Unit A:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="xmu3APath"/>
+               </item>
+               <item>
+                <widget class="QPushButton" name="setXmu3A">
+                 <property name="text">
+                  <string>Choose...</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_14">
+               <item>
+                <widget class="QLabel" name="xmuLabel3B">
+                 <property name="text">
+                  <string>Memory Unit B:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="xmu3BPath"/>
+               </item>
+               <item>
+                <widget class="QPushButton" name="setXmu3B">
+                 <property name="text">
+                  <string>Choose...</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -591,8 +603,15 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_19">
           <item>
-           <layout class="QGridLayout" name="gridLayout_11">
-            <item row="0" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <item>
+             <widget class="QLabel" name="label_16">
+              <property name="text">
+               <string>Controller:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QComboBox" name="controller4">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -632,56 +651,55 @@
               </item>
              </widget>
             </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_21">
-              <property name="text">
-               <string>Memory Unit A:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_16">
-              <property name="text">
-               <string>Controller:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_24">
-              <property name="text">
-               <string>Memory Unit B:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_15">
-              <item>
-               <widget class="QLineEdit" name="xmu4APath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu4A">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="2" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_16">
-              <item>
-               <widget class="QLineEdit" name="xmu4BPath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu4B">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
            </layout>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="controller4Additional">
+            <layout class="QVBoxLayout" name="_3">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_15">
+               <item>
+                <widget class="QLabel" name="xmuLabel4A">
+                 <property name="text">
+                  <string>Memory Unit A:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="xmu4APath"/>
+               </item>
+               <item>
+                <widget class="QPushButton" name="setXmu4A">
+                 <property name="text">
+                  <string>Choose...</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_16">
+               <item>
+                <widget class="QLabel" name="xmuLabel4B">
+                 <property name="text">
+                  <string>Memory Unit B:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="xmu4BPath"/>
+               </item>
+               <item>
+                <widget class="QPushButton" name="setXmu4B">
+                 <property name="text">
+                  <string>Choose...</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -693,22 +711,15 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_16">
           <item>
-           <layout class="QGridLayout" name="gridLayout_3">
-            <item row="0" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
              <widget class="QLabel" name="label_13">
               <property name="text">
                <string>Controller:</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_17">
-              <property name="text">
-               <string>Memory Unit A:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
+            <item>
              <widget class="QComboBox" name="controller1">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -748,48 +759,61 @@
               </item>
              </widget>
             </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_18">
-              <property name="text">
-               <string>Memory Unit B:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_9">
-              <item>
-               <widget class="QLineEdit" name="xmu1APath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu1A">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="2" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_11">
-              <item>
-               <widget class="QLineEdit" name="xmu1BPath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu1B">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
            </layout>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="controller1Additional">
+            <layout class="QVBoxLayout" name="_5">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_9">
+               <item>
+                <widget class="QLabel" name="xmuLabel1A">
+                 <property name="text">
+                  <string>Memory Unit A:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="xmu1APath"/>
+               </item>
+               <item>
+                <widget class="QPushButton" name="setXmu1A">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Choose...</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_11">
+               <item>
+                <widget class="QLabel" name="xmuLabel1B">
+                 <property name="text">
+                  <string>Memory Unit B:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="xmu1BPath"/>
+               </item>
+               <item>
+                <widget class="QPushButton" name="setXmu1B">
+                 <property name="text">
+                  <string>Choose...</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
Thrimbor had some code to /grey out/ MU selection based on if a controller was connected or not, this PR uses that code and simplifies the selection process.

This should be it's own method that's called much like `updateLaunchCmd()` to hide multiple things such as Debug options, networking, etc; but for now this is a good solution.