### PR TITLE
:sparkles: Game library

### DIFF
--- a/main.py
+++ b/main.py
@@ -389,23 +389,23 @@ class MainWindow(QMainWindow, mainwindow_class):
 		self.settings.load()
 		self.fileformats = [
 			{
-				'name': 'ISO9660 CD/DVD image file',
-				'offset': [
-					0x8001,
-					0x8801,
-					0x9001
-				],
-				'signature': [
-					'43 44 30 30 31'
-				]
-			},
-			{
 				'name': 'XISO',
 				'offset': [
 					0x10000
 				],
 				'signature': [
-					" ".join("{:02x}".format(ord(c)) for c in 'MICROSOFT*XBOX*MEDIA')
+					" ".join("{:02x}".format(ord(c)) for c in 'MICROSOFT*XBOX*MEDIA').upper()
+				]
+			},
+			{
+				'name': 'ISO9660 CD/DVD image file',
+				'offset': [
+					0x9001,
+					0x8801,
+					0x8001
+				],
+				'signature': [
+					'43 44 30 30 31'
 				]
 			}
 		]

--- a/main.py
+++ b/main.py
@@ -13,6 +13,8 @@ import json
 import subprocess
 import time
 import platform
+import sys
+print(sys.version)
 
 SETTINGS_FILE = './settings.json'
 
@@ -28,7 +30,7 @@ def getFormat(fileformats, settings, filename):
 	for element in fileformats:
 		for offset in element['offset']:
 			file = open(settings.settings['iso_path'] + '/' + filename, 'rb')
-			hex_bytes = " ".join(['{:02X}'.format(byte) for byte in read_from_hex_offset(file, offset)])
+			hex_bytes = " ".join("{:02x}".format(ord(c)) for c in read_from_hex_offset(file, offset))
 			for signature in element["signature"]:
 				if signature == hex_bytes[0:len(signature)].upper():
 					return element['name']

--- a/main.py
+++ b/main.py
@@ -22,8 +22,8 @@ settings_class, _ = loadUiType('settings.ui')
 mainwindow_class, _ = loadUiType('mainwindow.ui')
 
 def read_from_hex_offset(file, hex_offset):
-    file.seek(hex_offset)
-    return file.read(32)
+	file.seek(hex_offset)
+	return file.read(32)
 
 def getFormat(fileformats, settings, filename):
 	for element in fileformats:

--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ def getFormat(fileformats, settings, filename):
 			file = open(settings.settings['iso_path'] + '/' + filename, 'rb')
 			hex_bytes = " ".join("{:02x}".format(ord(c)) for c in read_from_hex_offset(file, offset))
 			for signature in element["signature"]:
-				if signature == hex_bytes[0:len(signature)].upper():
+				if signature == hex_bytes.replace(' ', '').decode('hex')[0:len(signature)]:
 					return element['name']
 
 class SettingsManager(object):
@@ -394,7 +394,7 @@ class MainWindow(QMainWindow, mainwindow_class):
 					0x10000
 				],
 				'signature': [
-					" ".join("{:02x}".format(ord(c)) for c in 'MICROSOFT*XBOX*MEDIA').upper()
+					'MICROSOFT*XBOX*MEDIA'
 				]
 			},
 			{
@@ -405,7 +405,7 @@ class MainWindow(QMainWindow, mainwindow_class):
 					0x8001
 				],
 				'signature': [
-					'43 44 30 30 31'
+					'CD001'
 				]
 			}
 		]

--- a/main.py
+++ b/main.py
@@ -123,6 +123,9 @@ class SettingsWindow(QDialog, settings_class):
 		def bindFilePicker(button, text):
 			button.clicked.connect(lambda:self.setSaveFileName(text))
 
+		def bindDirectoryPicker(button, text):
+			button.clicked.connect(lambda:self.setDirectory(text))
+
 		def bindDropdownWidget(widget, var):
 			getDropdownAttr(widget, var)
 			widget.currentIndexChanged.connect(lambda:setDropdownAttr(widget, var))
@@ -132,7 +135,7 @@ class SettingsWindow(QDialog, settings_class):
 		bindFilePicker(self.setXqemuPath, self.xqemuPath)
 		bindCheckWidget(self.useShortBootAnim, 'short_anim')
 		bindTextWidget(self.isoPath, 'iso_path')
-		bindFilePicker(self.setIsoPath, self.isoPath)
+		bindDirectoryPicker(self.setIsoPath, self.isoPath)
 		bindTextWidget(self.mcpxPath, 'mcpx_path')
 		bindFilePicker(self.setMcpxPath, self.mcpxPath)
 		bindTextWidget(self.flashPath, 'flash_path')
@@ -169,6 +172,15 @@ class SettingsWindow(QDialog, settings_class):
 		updateLaunchCmd()
 
 	def setSaveFileName(self, obj):
+		options = QFileDialog.Options()
+		fileName, _ = QFileDialog.getOpenFileName(self,
+				"Select File",
+				obj.text(),
+				"All Files (*)", options=options)
+		if fileName:
+			obj.setText(fileName)
+
+	def setDirectory(self, obj):
 		options = QFileDialog.Options()
 		directory = QFileDialog.getExistingDirectory(self,
 				"Select ISO Directory",
@@ -261,7 +273,7 @@ class Xqemu(object):
 		accelerator_arg = Xqemu.generateAcceleratorArg(settings.settings['use_accelerator'])
 
 		dvd_path_arg = ''
-		if mwindow.tableGames.currentRow() != 0:
+		if mwindow.tableGames.currentRow() > 0:
 			selectedGame = settings.settings['iso_path'] + '/' + mwindow.tableGames.item(mwindow.tableGames.currentRow(), 0).text()
 			check_path(selectedGame)
 			dvd_path_arg = ',file=' + escape_path(selectedGame)

--- a/main.py
+++ b/main.py
@@ -14,7 +14,6 @@ import subprocess
 import time
 import platform
 import sys
-print(sys.version)
 
 SETTINGS_FILE = './settings.json'
 
@@ -276,7 +275,7 @@ class Xqemu(object):
 
 		dvd_path_arg = ''
 		if mwindow.tableGames.currentRow() > 0:
-			selectedGame = settings.settings['iso_path'] + '/' + mwindow.tableGames.item(mwindow.tableGames.currentRow(), 0).text()
+			selectedGame = settings.settings['iso_path'] + '/' + mwindow.tableGames.item(mwindow.tableGames.currentRow(), 0).text().split('\n')[1]
 			check_path(selectedGame)
 			dvd_path_arg = ',file=' + escape_path(selectedGame)
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1,111 +1,111 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-	<class>MainWindow</class>
-	<widget class="QMainWindow" name="MainWindow">
-		<property name="geometry">
-			<rect>
-				<x>0</x>
-				<y>0</y>
-				<width>540</width>
-				<height>293</height>
-			</rect>
-		</property>
-		<property name="windowTitle">
-			<string>XQEMU Manager</string>
-		</property>
-		<widget class="QWidget" name="centralwidget">
-			<layout class="QVBoxLayout" name="verticalLayout">
-				<item>
-					<widget class="QTableWidget" name="tableGames">
-						<property name="geometry">
-							<rect>
-								<x>25</x>
-								<y>5</y>
-								<width>531</width>
-								<height>288</height>
-							</rect>
-						</property>
-					</widget>
-				</item>
-			</layout>
-		</widget>
-		<widget class="QStatusBar" name="statusbar" />
-		<widget class="QMenuBar" name="menubar">
-			<property name="geometry">
-				<rect>
-					<x>0</x>
-					<y>0</y>
-					<width>540</width>
-					<height>22</height>
-				</rect>
-			</property>
-			<property name="defaultUp">
-				<bool>false</bool>
-			</property>
-			<property name="nativeMenuBar">
-				<bool>false</bool>
-			</property>
-			<widget class="QMenu" name="menuFile">
-				<property name="title">
-					<string>File</string>
-				</property>
-				<addaction name="actionExit" />
-			</widget>
-			<widget class="QMenu" name="menuEdit">
-				<property name="title">
-					<string>&amp;Edit</string>
-				</property>
-				<addaction name="actionSettings" />
-			</widget>
-			<widget class="QMenu" name="menuEmulator">
-				<property name="title">
-					<string>Em&amp;ulator</string>
-				</property>
-				<addaction name="actionRun" />
-				<addaction name="actionPause" />
-				<addaction name="actionRestart" />
-				<addaction name="actionScreenshot" />
-			</widget>
-			<addaction name="menuFile" />
-			<addaction name="menuEdit" />
-			<addaction name="menuEmulator" />
-		</widget>
-		<action name="actionRun">
-			<property name="text">
-				<string>&amp;Run</string>
-			</property>
-		</action>
-		<action name="actionPause">
-			<property name="text">
-				<string>&amp;Pause</string>
-			</property>
-		</action>
-		<action name="actionRestart">
-			<property name="text">
-				<string>Res&amp;tart</string>
-			</property>
-		</action>
-		<action name="actionScreenshot">
-			<property name="text">
-				<string>&amp;Screenshot</string>
-			</property>
-		</action>
-		<action name="actionExit">
-			<property name="text">
-				<string>E&amp;xit</string>
-			</property>
-		</action>
-		<action name="actionSettings">
-			<property name="text">
-				<string>&amp;Settings</string>
-			</property>
-		</action>
-		<action name="actionAbout">
-			<property name="text">
-				<string>&amp;About</string>
-			</property>
-		</action>
-	</widget>
-	<resources />
-	<connections />
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>540</width>
+    <height>293</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>XQEMU Manager</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QTableWidget" name="tableGames">
+      <property name="geometry">
+       <rect>
+        <x>25</x>
+        <y>5</y>
+        <width>531</width>
+        <height>288</height>
+       </rect>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QStatusBar" name="statusbar" />
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>540</width>
+     <height>22</height>
+    </rect>
+   </property>
+   <property name="defaultUp">
+    <bool>false</bool>
+   </property>
+   <property name="nativeMenuBar">
+    <bool>false</bool>
+   </property>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>File</string>
+    </property>
+    <addaction name="actionExit" />
+   </widget>
+   <widget class="QMenu" name="menuEdit">
+    <property name="title">
+     <string>&amp;Edit</string>
+    </property>
+    <addaction name="actionSettings" />
+   </widget>
+   <widget class="QMenu" name="menuEmulator">
+    <property name="title">
+     <string>Em&amp;ulator</string>
+    </property>
+    <addaction name="actionRun" />
+    <addaction name="actionPause" />
+    <addaction name="actionRestart" />
+    <addaction name="actionScreenshot" />
+   </widget>
+   <addaction name="menuFile" />
+   <addaction name="menuEdit" />
+   <addaction name="menuEmulator" />
+  </widget>
+  <action name="actionRun">
+   <property name="text">
+    <string>&amp;Run</string>
+   </property>
+  </action>
+  <action name="actionPause">
+   <property name="text">
+    <string>&amp;Pause</string>
+   </property>
+  </action>
+  <action name="actionRestart">
+   <property name="text">
+    <string>Res&amp;tart</string>
+   </property>
+  </action>
+  <action name="actionScreenshot">
+   <property name="text">
+    <string>&amp;Screenshot</string>
+   </property>
+  </action>
+  <action name="actionExit">
+   <property name="text">
+    <string>E&amp;xit</string>
+   </property>
+  </action>
+  <action name="actionSettings">
+   <property name="text">
+    <string>&amp;Settings</string>
+   </property>
+  </action>
+  <action name="actionAbout">
+   <property name="text">
+    <string>&amp;About</string>
+   </property>
+  </action>
+ </widget>
+ <resources />
+ <connections />
 </ui>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1,110 +1,111 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>MainWindow</class>
- <widget class="QMainWindow" name="MainWindow">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>410</width>
-    <height>293</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>XQEMU Manager</string>
-  </property>
-  <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <widget class="QPushButton" name="runButton">
-      <property name="text">
-       <string>Start</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="pauseButton">
-      <property name="text">
-       <string>Pause</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="restartButton">
-      <property name="text">
-       <string>Restart</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="screenshotButton">
-      <property name="text">
-       <string>Screenshot</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <spacer name="verticalSpacer">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>20</width>
-        <height>40</height>
-       </size>
-      </property>
-     </spacer>
-    </item>
-   </layout>
-  </widget>
-  <widget class="QStatusBar" name="statusbar"/>
-  <widget class="QMenuBar" name="menubar">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>410</width>
-     <height>22</height>
-    </rect>
-   </property>
-   <property name="defaultUp">
-    <bool>false</bool>
-   </property>
-   <property name="nativeMenuBar">
-    <bool>false</bool>
-   </property>
-   <widget class="QMenu" name="menuFile">
-    <property name="title">
-     <string>File</string>
-    </property>
-    <addaction name="actionExit"/>
-   </widget>
-   <widget class="QMenu" name="menuEdit">
-    <property name="title">
-     <string>&amp;Edit</string>
-    </property>
-    <addaction name="actionSettings"/>
-   </widget>
-   <addaction name="menuFile"/>
-   <addaction name="menuEdit"/>
-  </widget>
-  <action name="actionExit">
-   <property name="text">
-    <string>E&amp;xit</string>
-   </property>
-  </action>
-  <action name="actionSettings">
-   <property name="text">
-    <string>&amp;Settings</string>
-   </property>
-  </action>
-  <action name="actionAbout">
-   <property name="text">
-    <string>&amp;About</string>
-   </property>
-  </action>
- </widget>
- <resources/>
- <connections/>
+	<class>MainWindow</class>
+	<widget class="QMainWindow" name="MainWindow">
+		<property name="geometry">
+			<rect>
+				<x>0</x>
+				<y>0</y>
+				<width>540</width>
+				<height>293</height>
+			</rect>
+		</property>
+		<property name="windowTitle">
+			<string>XQEMU Manager</string>
+		</property>
+		<widget class="QWidget" name="centralwidget">
+			<layout class="QVBoxLayout" name="verticalLayout">
+				<item>
+					<widget class="QTableWidget" name="tableGames">
+						<property name="geometry">
+							<rect>
+								<x>25</x>
+								<y>5</y>
+								<width>531</width>
+								<height>288</height>
+							</rect>
+						</property>
+					</widget>
+				</item>
+			</layout>
+		</widget>
+		<widget class="QStatusBar" name="statusbar" />
+		<widget class="QMenuBar" name="menubar">
+			<property name="geometry">
+				<rect>
+					<x>0</x>
+					<y>0</y>
+					<width>540</width>
+					<height>22</height>
+				</rect>
+			</property>
+			<property name="defaultUp">
+				<bool>false</bool>
+			</property>
+			<property name="nativeMenuBar">
+				<bool>false</bool>
+			</property>
+			<widget class="QMenu" name="menuFile">
+				<property name="title">
+					<string>File</string>
+				</property>
+				<addaction name="actionExit" />
+			</widget>
+			<widget class="QMenu" name="menuEdit">
+				<property name="title">
+					<string>&amp;Edit</string>
+				</property>
+				<addaction name="actionSettings" />
+			</widget>
+			<widget class="QMenu" name="menuEmulator">
+				<property name="title">
+					<string>Em&amp;ulator</string>
+				</property>
+				<addaction name="actionRun" />
+				<addaction name="actionPause" />
+				<addaction name="actionRestart" />
+				<addaction name="actionScreenshot" />
+			</widget>
+			<addaction name="menuFile" />
+			<addaction name="menuEdit" />
+			<addaction name="menuEmulator" />
+		</widget>
+		<action name="actionRun">
+			<property name="text">
+				<string>&amp;Run</string>
+			</property>
+		</action>
+		<action name="actionPause">
+			<property name="text">
+				<string>&amp;Pause</string>
+			</property>
+		</action>
+		<action name="actionRestart">
+			<property name="text">
+				<string>Res&amp;tart</string>
+			</property>
+		</action>
+		<action name="actionScreenshot">
+			<property name="text">
+				<string>&amp;Screenshot</string>
+			</property>
+		</action>
+		<action name="actionExit">
+			<property name="text">
+				<string>E&amp;xit</string>
+			</property>
+		</action>
+		<action name="actionSettings">
+			<property name="text">
+				<string>&amp;Settings</string>
+			</property>
+		</action>
+		<action name="actionAbout">
+			<property name="text">
+				<string>&amp;About</string>
+			</property>
+		</action>
+	</widget>
+	<resources />
+	<connections />
 </ui>

--- a/settings.ui
+++ b/settings.ui
@@ -1,1017 +1,1016 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Dialog</class>
- <widget class="QDialog" name="Dialog">
-  <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
-  </property>
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>660</width>
-    <height>352</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Settings</string>
-  </property>
-  <property name="modal">
-   <bool>true</bool>
-  </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
-   <item>
-    <widget class="QTabWidget" name="tabWidget">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="generalTab">
-      <attribute name="title">
-       <string>General</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QGroupBox" name="groupBox_8">
-         <property name="title">
-          <string>XQEMU</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_15">
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <item>
-             <widget class="QLabel" name="label_12">
-              <property name="text">
-               <string>XQEMU Executable:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="xqemuPath"/>
-            </item>
-            <item>
-             <widget class="QPushButton" name="setXqemuPath">
-              <property name="text">
-               <string>Choose...</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="useAccelerator">
-            <property name="text">
-             <string>Use hardware CPU acceleration</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="bootOptionsGroup">
-         <property name="title">
-          <string>Boot Options</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_7">
-          <item>
-           <widget class="QCheckBox" name="useShortBootAnim">
-            <property name="text">
-             <string>Use short boot animation sequence</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="dvdDriveGroup">
-         <property name="title">
-          <string>DVD Drive</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_5">
-          <item>
-           <widget class="QCheckBox" name="dvdPresent">
-            <property name="text">
-             <string>Disc Present</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QGridLayout" name="gridLayout_5">
-            <item row="0" column="1">
-             <widget class="QLineEdit" name="dvdPath">
-              <property name="readOnly">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_9">
-              <property name="text">
-               <string>Disc Image:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
-             <widget class="QPushButton" name="setDvdPath">
-              <property name="text">
-               <string>Choose...</string>
-              </property>
-              <property name="checkable">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="systemTab">
-      <attribute name="title">
-       <string>System</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
-        <widget class="QGroupBox" name="groupBox">
-         <property name="title">
-          <string>Firmware</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
-           <layout class="QGridLayout" name="gridLayout">
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_2">
-              <property name="text">
-               <string>Flash Image:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QLineEdit" name="mcpxPath">
-              <property name="readOnly">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QLineEdit" name="flashPath">
-              <property name="readOnly">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>MCPX ROM Image:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="2">
-             <widget class="QPushButton" name="setFlashPath">
-              <property name="text">
-               <string>Choose...</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
-             <widget class="QPushButton" name="setMcpxPath">
-              <property name="text">
-               <string>Choose...</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox_2">
-         <property name="title">
-          <string>Hard Disk</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <item>
-           <layout class="QGridLayout" name="gridLayout_4">
-            <item row="0" column="1">
-             <widget class="QLineEdit" name="hddPath">
-              <property name="readOnly">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_8">
-              <property name="text">
-               <string>HDD Image:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
-             <widget class="QPushButton" name="setHddPath">
-              <property name="text">
-               <string>Choose...</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="hddLocked">
-            <property name="text">
-             <string>Locked</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox_4">
-         <property name="title">
-          <string>Memory</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_6">
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <item>
-             <widget class="QLabel" name="label_3">
-              <property name="text">
-               <string>Installed System Memory:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="systemMemory">
-              <item>
-               <property name="text">
-                <string>64 MiB</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>128 MiB</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="networkTab">
-      <attribute name="title">
-       <string>Network</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_12">
-       <item>
-        <widget class="QGroupBox" name="groupBox_3">
-         <property name="title">
-          <string>Hardware</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_13">
-          <item>
-           <widget class="QCheckBox" name="checkBox_2">
-            <property name="text">
-             <string>Cable Connected</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QGridLayout" name="gridLayout_2">
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_11">
-              <property name="text">
-               <string>Attached To:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="label_10">
-              <property name="text">
-               <string>MAC Address:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QComboBox" name="comboBox_2"/>
-            </item>
-            <item row="3" column="1">
-             <widget class="QLineEdit" name="lineEdit"/>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox_6">
-         <property name="title">
-          <string>Port Forwarding</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_14">
-          <item>
-           <widget class="QTableWidget" name="tableWidget">
-            <column>
-             <property name="text">
-              <string>Name</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Protocol</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Host Port</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Guest Port</string>
-             </property>
-            </column>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="inputTab">
-      <attribute name="title">
-       <string>Input Devices</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_8">
-       <item row="0" column="1">
-        <widget class="QGroupBox" name="controller2Box">
-         <property name="title">
-          <string>Port 2</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_17">
-          <item>
-           <layout class="QGridLayout" name="gridLayout_9">
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_14">
-              <property name="text">
-               <string>Controller:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_10">
-              <item>
-               <widget class="QLineEdit" name="xmu2APath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu2A">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="2" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_12">
-              <item>
-               <widget class="QLineEdit" name="xmu2BPath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu2B">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_19">
-              <property name="text">
-               <string>Memory Unit A:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QComboBox" name="controller2">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <item>
-               <property name="text">
-                <string>Not connected</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Keyboard</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #0</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #1</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #2</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #3</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_22">
-              <property name="text">
-               <string>Memory Unit B:</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QGroupBox" name="controller3Box">
-         <property name="title">
-          <string>Port 3</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_18">
-          <item>
-           <layout class="QGridLayout" name="gridLayout_10">
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_15">
-              <property name="text">
-               <string>Controller:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QComboBox" name="controller3">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <item>
-               <property name="text">
-                <string>Not connected</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Keyboard</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #0</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #1</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #2</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #3</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_20">
-              <property name="text">
-               <string>Memory Unit A:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_23">
-              <property name="text">
-               <string>Memory Unit B:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_13">
-              <item>
-               <widget class="QLineEdit" name="xmu3APath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu3A">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="2" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_14">
-              <item>
-               <widget class="QLineEdit" name="xmu3BPath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu3B">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QGroupBox" name="controller4Box">
-         <property name="title">
-          <string>Port 4</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_19">
-          <item>
-           <layout class="QGridLayout" name="gridLayout_11">
-            <item row="0" column="1">
-             <widget class="QComboBox" name="controller4">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <item>
-               <property name="text">
-                <string>Not connected</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Keyboard</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #0</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #1</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #2</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #3</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_21">
-              <property name="text">
-               <string>Memory Unit A:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_16">
-              <property name="text">
-               <string>Controller:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_24">
-              <property name="text">
-               <string>Memory Unit B:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_15">
-              <item>
-               <widget class="QLineEdit" name="xmu4APath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu4A">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="2" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_16">
-              <item>
-               <widget class="QLineEdit" name="xmu4BPath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu4B">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QGroupBox" name="controller1Box">
-         <property name="title">
-          <string>Port 1</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_16">
-          <item>
-           <layout class="QGridLayout" name="gridLayout_3">
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_13">
-              <property name="text">
-               <string>Controller:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_17">
-              <property name="text">
-               <string>Memory Unit A:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QComboBox" name="controller1">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <item>
-               <property name="text">
-                <string>Not connected</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Keyboard</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #0</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #1</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #2</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Gamepad #3</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_18">
-              <property name="text">
-               <string>Memory Unit B:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_9">
-              <item>
-               <widget class="QLineEdit" name="xmu1APath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu1A">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="2" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout_11">
-              <item>
-               <widget class="QLineEdit" name="xmu1BPath"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="setXmu1B">
-                <property name="text">
-                 <string>Choose...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="debugTab">
-      <attribute name="title">
-       <string>Debug</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_8">
-       <item>
-        <widget class="QGroupBox" name="groupBox_5">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="title">
-          <string>SuperIO</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_9">
-          <item>
-           <widget class="QCheckBox" name="checkBox">
-            <property name="text">
-             <string>Enable SuperIO</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox_7">
-         <property name="title">
-          <string>GDB Server</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_10">
-          <item>
-           <widget class="QCheckBox" name="gdbEnabled">
-            <property name="text">
-             <string>Enable GDB Server</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="waitForGdb">
-            <property name="text">
-             <string>Wait for connection at startup</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <item>
-             <widget class="QLabel" name="label_4">
-              <property name="text">
-               <string>GDB Server Port:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="gdbPort">
-              <property name="maximumSize">
-               <size>
-                <width>100</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="placeholderText">
-               <string>1234</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="cliTab">
-      <attribute name="title">
-       <string>CLI</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_8">
-       <item>
-        <widget class="QGroupBox" name="groupBox_10">
-         <property name="title">
-          <string>Additonal arguments</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_7">
-          <item row="0" column="0">
-           <widget class="QLineEdit" name="additionalArgs"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox_9">
-         <property name="title">
-          <string>XQEMU invocation preview</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_6">
-          <item row="0" column="0">
-           <widget class="QPlainTextEdit" name="invocationPreview">
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="aboutTab">
-      <attribute name="title">
-       <string>About</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_11">
-       <item>
-        <spacer name="verticalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_5">
-         <property name="font">
-          <font>
-           <pointsize>24</pointsize>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>xqemu manager</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="copyrightLabel">
-         <property name="text">
-          <string>Copyright (C) 2018, XQEMU Developers</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>Version: 0123456789</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_7">
-         <property name="text">
-          <string>This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-  </layout>
- </widget>
- <resources/>
- <connections/>
+	<class>Dialog</class>
+	<widget class="QDialog" name="Dialog">
+		<property name="windowModality">
+			<enum>Qt::WindowModal</enum>
+		</property>
+		<property name="geometry">
+			<rect>
+				<x>0</x>
+				<y>0</y>
+				<width>660</width>
+				<height>352</height>
+			</rect>
+		</property>
+		<property name="windowTitle">
+			<string>Settings</string>
+		</property>
+		<property name="modal">
+			<bool>true</bool>
+		</property>
+		<layout class="QHBoxLayout" name="horizontalLayout">
+			<item>
+				<widget class="QTabWidget" name="tabWidget">
+					<property name="enabled">
+						<bool>true</bool>
+					</property>
+					<property name="currentIndex">
+						<number>0</number>
+					</property>
+					<widget class="QWidget" name="generalTab">
+						<attribute name="title">
+							<string>General</string>
+						</attribute>
+						<layout class="QVBoxLayout" name="verticalLayout">
+							<item>
+								<widget class="QGroupBox" name="groupBox_8">
+									<property name="title">
+										<string>XQEMU</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_15">
+										<item>
+											<layout class="QHBoxLayout" name="horizontalLayout_4">
+												<item>
+													<widget class="QLabel" name="label_12">
+														<property name="text">
+															<string>XQEMU Executable:</string>
+														</property>
+													</widget>
+												</item>
+												<item>
+													<widget class="QLineEdit" name="xqemuPath" />
+												</item>
+												<item>
+													<widget class="QPushButton" name="setXqemuPath">
+														<property name="text">
+															<string>Choose...</string>
+														</property>
+													</widget>
+												</item>
+											</layout>
+										</item>
+										<item>
+											<widget class="QCheckBox" name="useAccelerator">
+												<property name="text">
+													<string>Use hardware CPU acceleration</string>
+												</property>
+											</widget>
+										</item>
+									</layout>
+								</widget>
+							</item>
+							<item>
+								<widget class="QGroupBox" name="bootOptionsGroup">
+									<property name="title">
+										<string>Boot Options</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_7">
+										<item>
+											<widget class="QCheckBox" name="useShortBootAnim">
+												<property name="text">
+													<string>Use short boot animation sequence</string>
+												</property>
+											</widget>
+										</item>
+									</layout>
+								</widget>
+							</item>
+							<item>
+								<widget class="QGroupBox" name="dvdDriveGroup">
+									<property name="title">
+										<string>ISO Folder</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_5">
+										<item>
+											<layout class="QGridLayout" name="gridLayout_5">
+												<item row="0" column="1">
+													<widget class="QLineEdit" name="isoPath">
+														<property name="readOnly">
+															<bool>false</bool>
+														</property>
+													</widget>
+												</item>
+												<item row="0" column="0">
+													<widget class="QLabel" name="label_9">
+														<property name="text">
+															<string>ISO Folder:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="0" column="2">
+													<widget class="QPushButton" name="setIsoPath">
+														<property name="text">
+															<string>Choose...</string>
+														</property>
+														<property name="checkable">
+															<bool>false</bool>
+														</property>
+													</widget>
+												</item>
+											</layout>
+										</item>
+									</layout>
+								</widget>
+							</item>
+							<item>
+								<spacer name="verticalSpacer">
+									<property name="orientation">
+										<enum>Qt::Vertical</enum>
+									</property>
+									<property name="sizeHint" stdset="0">
+										<size>
+											<width>20</width>
+											<height>40</height>
+										</size>
+									</property>
+								</spacer>
+							</item>
+						</layout>
+					</widget>
+					<widget class="QWidget" name="systemTab">
+						<attribute name="title">
+							<string>System</string>
+						</attribute>
+						<layout class="QVBoxLayout" name="verticalLayout_4">
+							<item>
+								<widget class="QGroupBox" name="groupBox">
+									<property name="title">
+										<string>Firmware</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_2">
+										<item>
+											<layout class="QGridLayout" name="gridLayout">
+												<item row="1" column="0">
+													<widget class="QLabel" name="label_2">
+														<property name="text">
+															<string>Flash Image:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="0" column="1">
+													<widget class="QLineEdit" name="mcpxPath">
+														<property name="readOnly">
+															<bool>false</bool>
+														</property>
+													</widget>
+												</item>
+												<item row="1" column="1">
+													<widget class="QLineEdit" name="flashPath">
+														<property name="readOnly">
+															<bool>false</bool>
+														</property>
+													</widget>
+												</item>
+												<item row="0" column="0">
+													<widget class="QLabel" name="label">
+														<property name="text">
+															<string>MCPX ROM Image:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="1" column="2">
+													<widget class="QPushButton" name="setFlashPath">
+														<property name="text">
+															<string>Choose...</string>
+														</property>
+													</widget>
+												</item>
+												<item row="0" column="2">
+													<widget class="QPushButton" name="setMcpxPath">
+														<property name="text">
+															<string>Choose...</string>
+														</property>
+													</widget>
+												</item>
+											</layout>
+										</item>
+									</layout>
+								</widget>
+							</item>
+							<item>
+								<widget class="QGroupBox" name="groupBox_2">
+									<property name="title">
+										<string>Hard Disk</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_3">
+										<item>
+											<layout class="QGridLayout" name="gridLayout_4">
+												<item row="0" column="1">
+													<widget class="QLineEdit" name="hddPath">
+														<property name="readOnly">
+															<bool>false</bool>
+														</property>
+													</widget>
+												</item>
+												<item row="0" column="0">
+													<widget class="QLabel" name="label_8">
+														<property name="text">
+															<string>HDD Image:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="0" column="2">
+													<widget class="QPushButton" name="setHddPath">
+														<property name="text">
+															<string>Choose...</string>
+														</property>
+													</widget>
+												</item>
+											</layout>
+										</item>
+										<item>
+											<widget class="QCheckBox" name="hddLocked">
+												<property name="text">
+													<string>Locked</string>
+												</property>
+											</widget>
+										</item>
+									</layout>
+								</widget>
+							</item>
+							<item>
+								<widget class="QGroupBox" name="groupBox_4">
+									<property name="title">
+										<string>Memory</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_6">
+										<item>
+											<layout class="QHBoxLayout" name="horizontalLayout_2">
+												<item>
+													<widget class="QLabel" name="label_3">
+														<property name="text">
+															<string>Installed System Memory:</string>
+														</property>
+													</widget>
+												</item>
+												<item>
+													<widget class="QComboBox" name="systemMemory">
+														<item>
+															<property name="text">
+																<string>64 MiB</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>128 MiB</string>
+															</property>
+														</item>
+													</widget>
+												</item>
+											</layout>
+										</item>
+									</layout>
+								</widget>
+							</item>
+							<item>
+								<spacer name="verticalSpacer_2">
+									<property name="orientation">
+										<enum>Qt::Vertical</enum>
+									</property>
+									<property name="sizeHint" stdset="0">
+										<size>
+											<width>20</width>
+											<height>40</height>
+										</size>
+									</property>
+								</spacer>
+							</item>
+						</layout>
+					</widget>
+					<widget class="QWidget" name="networkTab">
+						<attribute name="title">
+							<string>Network</string>
+						</attribute>
+						<layout class="QVBoxLayout" name="verticalLayout_12">
+							<item>
+								<widget class="QGroupBox" name="groupBox_3">
+									<property name="title">
+										<string>Hardware</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_13">
+										<item>
+											<widget class="QCheckBox" name="checkBox_2">
+												<property name="text">
+													<string>Cable Connected</string>
+												</property>
+											</widget>
+										</item>
+										<item>
+											<layout class="QGridLayout" name="gridLayout_2">
+												<item row="0" column="0">
+													<widget class="QLabel" name="label_11">
+														<property name="text">
+															<string>Attached To:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="3" column="0">
+													<widget class="QLabel" name="label_10">
+														<property name="text">
+															<string>MAC Address:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="0" column="1">
+													<widget class="QComboBox" name="comboBox_2" />
+												</item>
+												<item row="3" column="1">
+													<widget class="QLineEdit" name="lineEdit" />
+												</item>
+											</layout>
+										</item>
+									</layout>
+								</widget>
+							</item>
+							<item>
+								<widget class="QGroupBox" name="groupBox_6">
+									<property name="title">
+										<string>Port Forwarding</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_14">
+										<item>
+											<widget class="QTableWidget" name="tableWidget">
+												<column>
+													<property name="text">
+														<string>Name</string>
+													</property>
+												</column>
+												<column>
+													<property name="text">
+														<string>Protocol</string>
+													</property>
+												</column>
+												<column>
+													<property name="text">
+														<string>Host Port</string>
+													</property>
+												</column>
+												<column>
+													<property name="text">
+														<string>Guest Port</string>
+													</property>
+												</column>
+											</widget>
+										</item>
+									</layout>
+								</widget>
+							</item>
+						</layout>
+					</widget>
+					<widget class="QWidget" name="inputTab">
+						<attribute name="title">
+							<string>Input Devices</string>
+						</attribute>
+						<layout class="QGridLayout" name="gridLayout_8">
+							<item row="0" column="1">
+								<widget class="QGroupBox" name="controller2Box">
+									<property name="title">
+										<string>Port 2</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_17">
+										<item>
+											<layout class="QGridLayout" name="gridLayout_9">
+												<item row="0" column="0">
+													<widget class="QLabel" name="label_14">
+														<property name="text">
+															<string>Controller:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="1" column="1">
+													<layout class="QHBoxLayout" name="horizontalLayout_10">
+														<item>
+															<widget class="QLineEdit" name="xmu2APath" />
+														</item>
+														<item>
+															<widget class="QPushButton" name="setXmu2A">
+																<property name="text">
+																	<string>Choose...</string>
+																</property>
+															</widget>
+														</item>
+													</layout>
+												</item>
+												<item row="2" column="1">
+													<layout class="QHBoxLayout" name="horizontalLayout_12">
+														<item>
+															<widget class="QLineEdit" name="xmu2BPath" />
+														</item>
+														<item>
+															<widget class="QPushButton" name="setXmu2B">
+																<property name="text">
+																	<string>Choose...</string>
+																</property>
+															</widget>
+														</item>
+													</layout>
+												</item>
+												<item row="1" column="0">
+													<widget class="QLabel" name="label_19">
+														<property name="text">
+															<string>Memory Unit A:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="0" column="1">
+													<widget class="QComboBox" name="controller2">
+														<property name="sizePolicy">
+															<sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+																<horstretch>0</horstretch>
+																<verstretch>0</verstretch>
+															</sizepolicy>
+														</property>
+														<item>
+															<property name="text">
+																<string>Not connected</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Keyboard</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #0</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #1</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #2</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #3</string>
+															</property>
+														</item>
+													</widget>
+												</item>
+												<item row="2" column="0">
+													<widget class="QLabel" name="label_22">
+														<property name="text">
+															<string>Memory Unit B:</string>
+														</property>
+													</widget>
+												</item>
+											</layout>
+										</item>
+									</layout>
+								</widget>
+							</item>
+							<item row="2" column="0">
+								<widget class="QGroupBox" name="controller3Box">
+									<property name="title">
+										<string>Port 3</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_18">
+										<item>
+											<layout class="QGridLayout" name="gridLayout_10">
+												<item row="0" column="0">
+													<widget class="QLabel" name="label_15">
+														<property name="text">
+															<string>Controller:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="0" column="1">
+													<widget class="QComboBox" name="controller3">
+														<property name="sizePolicy">
+															<sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+																<horstretch>0</horstretch>
+																<verstretch>0</verstretch>
+															</sizepolicy>
+														</property>
+														<item>
+															<property name="text">
+																<string>Not connected</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Keyboard</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #0</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #1</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #2</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #3</string>
+															</property>
+														</item>
+													</widget>
+												</item>
+												<item row="1" column="0">
+													<widget class="QLabel" name="label_20">
+														<property name="text">
+															<string>Memory Unit A:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="2" column="0">
+													<widget class="QLabel" name="label_23">
+														<property name="text">
+															<string>Memory Unit B:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="1" column="1">
+													<layout class="QHBoxLayout" name="horizontalLayout_13">
+														<item>
+															<widget class="QLineEdit" name="xmu3APath" />
+														</item>
+														<item>
+															<widget class="QPushButton" name="setXmu3A">
+																<property name="text">
+																	<string>Choose...</string>
+																</property>
+															</widget>
+														</item>
+													</layout>
+												</item>
+												<item row="2" column="1">
+													<layout class="QHBoxLayout" name="horizontalLayout_14">
+														<item>
+															<widget class="QLineEdit" name="xmu3BPath" />
+														</item>
+														<item>
+															<widget class="QPushButton" name="setXmu3B">
+																<property name="text">
+																	<string>Choose...</string>
+																</property>
+															</widget>
+														</item>
+													</layout>
+												</item>
+											</layout>
+										</item>
+									</layout>
+								</widget>
+							</item>
+							<item row="2" column="1">
+								<widget class="QGroupBox" name="controller4Box">
+									<property name="title">
+										<string>Port 4</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_19">
+										<item>
+											<layout class="QGridLayout" name="gridLayout_11">
+												<item row="0" column="1">
+													<widget class="QComboBox" name="controller4">
+														<property name="sizePolicy">
+															<sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+																<horstretch>0</horstretch>
+																<verstretch>0</verstretch>
+															</sizepolicy>
+														</property>
+														<item>
+															<property name="text">
+																<string>Not connected</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Keyboard</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #0</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #1</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #2</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #3</string>
+															</property>
+														</item>
+													</widget>
+												</item>
+												<item row="1" column="0">
+													<widget class="QLabel" name="label_21">
+														<property name="text">
+															<string>Memory Unit A:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="0" column="0">
+													<widget class="QLabel" name="label_16">
+														<property name="text">
+															<string>Controller:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="2" column="0">
+													<widget class="QLabel" name="label_24">
+														<property name="text">
+															<string>Memory Unit B:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="1" column="1">
+													<layout class="QHBoxLayout" name="horizontalLayout_15">
+														<item>
+															<widget class="QLineEdit" name="xmu4APath" />
+														</item>
+														<item>
+															<widget class="QPushButton" name="setXmu4A">
+																<property name="text">
+																	<string>Choose...</string>
+																</property>
+															</widget>
+														</item>
+													</layout>
+												</item>
+												<item row="2" column="1">
+													<layout class="QHBoxLayout" name="horizontalLayout_16">
+														<item>
+															<widget class="QLineEdit" name="xmu4BPath" />
+														</item>
+														<item>
+															<widget class="QPushButton" name="setXmu4B">
+																<property name="text">
+																	<string>Choose...</string>
+																</property>
+															</widget>
+														</item>
+													</layout>
+												</item>
+											</layout>
+										</item>
+									</layout>
+								</widget>
+							</item>
+							<item row="0" column="0">
+								<widget class="QGroupBox" name="controller1Box">
+									<property name="title">
+										<string>Port 1</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_16">
+										<item>
+											<layout class="QGridLayout" name="gridLayout_3">
+												<item row="0" column="0">
+													<widget class="QLabel" name="label_13">
+														<property name="text">
+															<string>Controller:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="1" column="0">
+													<widget class="QLabel" name="label_17">
+														<property name="text">
+															<string>Memory Unit A:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="0" column="1">
+													<widget class="QComboBox" name="controller1">
+														<property name="sizePolicy">
+															<sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+																<horstretch>0</horstretch>
+																<verstretch>0</verstretch>
+															</sizepolicy>
+														</property>
+														<item>
+															<property name="text">
+																<string>Not connected</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Keyboard</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #0</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #1</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #2</string>
+															</property>
+														</item>
+														<item>
+															<property name="text">
+																<string>Gamepad #3</string>
+															</property>
+														</item>
+													</widget>
+												</item>
+												<item row="2" column="0">
+													<widget class="QLabel" name="label_18">
+														<property name="text">
+															<string>Memory Unit B:</string>
+														</property>
+													</widget>
+												</item>
+												<item row="1" column="1">
+													<layout class="QHBoxLayout" name="horizontalLayout_9">
+														<item>
+															<widget class="QLineEdit" name="xmu1APath" />
+														</item>
+														<item>
+															<widget class="QPushButton" name="setXmu1A">
+																<property name="sizePolicy">
+																	<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+																		<horstretch>0</horstretch>
+																		<verstretch>0</verstretch>
+																	</sizepolicy>
+																</property>
+																<property name="text">
+																	<string>Choose...</string>
+																</property>
+															</widget>
+														</item>
+													</layout>
+												</item>
+												<item row="2" column="1">
+													<layout class="QHBoxLayout" name="horizontalLayout_11">
+														<item>
+															<widget class="QLineEdit" name="xmu1BPath" />
+														</item>
+														<item>
+															<widget class="QPushButton" name="setXmu1B">
+																<property name="text">
+																	<string>Choose...</string>
+																</property>
+															</widget>
+														</item>
+													</layout>
+												</item>
+											</layout>
+										</item>
+									</layout>
+								</widget>
+							</item>
+						</layout>
+					</widget>
+					<widget class="QWidget" name="debugTab">
+						<attribute name="title">
+							<string>Debug</string>
+						</attribute>
+						<layout class="QVBoxLayout" name="verticalLayout_8">
+							<item>
+								<widget class="QGroupBox" name="groupBox_5">
+									<property name="enabled">
+										<bool>false</bool>
+									</property>
+									<property name="title">
+										<string>SuperIO</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_9">
+										<item>
+											<widget class="QCheckBox" name="checkBox">
+												<property name="text">
+													<string>Enable SuperIO</string>
+												</property>
+											</widget>
+										</item>
+									</layout>
+								</widget>
+							</item>
+							<item>
+								<widget class="QGroupBox" name="groupBox_7">
+									<property name="title">
+										<string>GDB Server</string>
+									</property>
+									<layout class="QVBoxLayout" name="verticalLayout_10">
+										<item>
+											<widget class="QCheckBox" name="gdbEnabled">
+												<property name="text">
+													<string>Enable GDB Server</string>
+												</property>
+											</widget>
+										</item>
+										<item>
+											<widget class="QCheckBox" name="waitForGdb">
+												<property name="text">
+													<string>Wait for connection at startup</string>
+												</property>
+											</widget>
+										</item>
+										<item>
+											<layout class="QHBoxLayout" name="horizontalLayout_3">
+												<item>
+													<widget class="QLabel" name="label_4">
+														<property name="text">
+															<string>GDB Server Port:</string>
+														</property>
+													</widget>
+												</item>
+												<item>
+													<widget class="QLineEdit" name="gdbPort">
+														<property name="maximumSize">
+															<size>
+																<width>100</width>
+																<height>16777215</height>
+															</size>
+														</property>
+														<property name="placeholderText">
+															<string>1234</string>
+														</property>
+													</widget>
+												</item>
+												<item>
+													<spacer name="horizontalSpacer">
+														<property name="orientation">
+															<enum>Qt::Horizontal</enum>
+														</property>
+														<property name="sizeHint" stdset="0">
+															<size>
+																<width>40</width>
+																<height>20</height>
+															</size>
+														</property>
+													</spacer>
+												</item>
+											</layout>
+										</item>
+									</layout>
+								</widget>
+							</item>
+							<item>
+								<spacer name="verticalSpacer_3">
+									<property name="orientation">
+										<enum>Qt::Vertical</enum>
+									</property>
+									<property name="sizeHint" stdset="0">
+										<size>
+											<width>20</width>
+											<height>40</height>
+										</size>
+									</property>
+								</spacer>
+							</item>
+						</layout>
+					</widget>
+					<widget class="QWidget" name="cliTab">
+						<attribute name="title">
+							<string>CLI</string>
+						</attribute>
+						<layout class="QVBoxLayout" name="verticalLayout_8">
+							<item>
+								<widget class="QGroupBox" name="groupBox_10">
+									<property name="title">
+										<string>Additonal arguments</string>
+									</property>
+									<layout class="QGridLayout" name="gridLayout_7">
+										<item row="0" column="0">
+											<widget class="QLineEdit" name="additionalArgs" />
+										</item>
+									</layout>
+								</widget>
+							</item>
+							<item>
+								<widget class="QGroupBox" name="groupBox_9">
+									<property name="title">
+										<string>XQEMU invocation preview</string>
+									</property>
+									<layout class="QGridLayout" name="gridLayout_6">
+										<item row="0" column="0">
+											<widget class="QPlainTextEdit" name="invocationPreview">
+												<property name="readOnly">
+													<bool>true</bool>
+												</property>
+											</widget>
+										</item>
+									</layout>
+								</widget>
+							</item>
+						</layout>
+					</widget>
+					<widget class="QWidget" name="aboutTab">
+						<attribute name="title">
+							<string>About</string>
+						</attribute>
+						<layout class="QVBoxLayout" name="verticalLayout_11">
+							<item>
+								<spacer name="verticalSpacer_5">
+									<property name="orientation">
+										<enum>Qt::Vertical</enum>
+									</property>
+									<property name="sizeHint" stdset="0">
+										<size>
+											<width>20</width>
+											<height>40</height>
+										</size>
+									</property>
+								</spacer>
+							</item>
+							<item>
+								<widget class="QLabel" name="label_5">
+									<property name="font">
+										<font>
+											<pointsize>24</pointsize>
+											<weight>75</weight>
+											<bold>true</bold>
+										</font>
+									</property>
+									<property name="text">
+										<string>xqemu manager</string>
+									</property>
+									<property name="alignment">
+										<set>Qt::AlignCenter</set>
+									</property>
+								</widget>
+							</item>
+							<item>
+								<widget class="QLabel" name="copyrightLabel">
+									<property name="text">
+										<string>Copyright (C) 2018, XQEMU Developers</string>
+									</property>
+									<property name="alignment">
+										<set>Qt::AlignCenter</set>
+									</property>
+								</widget>
+							</item>
+							<item>
+								<spacer name="verticalSpacer_4">
+									<property name="orientation">
+										<enum>Qt::Vertical</enum>
+									</property>
+									<property name="sizeHint" stdset="0">
+										<size>
+											<width>20</width>
+											<height>40</height>
+										</size>
+									</property>
+								</spacer>
+							</item>
+							<item>
+								<widget class="QLabel" name="label_6">
+									<property name="text">
+										<string>Version: 0123456789</string>
+									</property>
+								</widget>
+							</item>
+							<item>
+								<widget class="QLabel" name="label_7">
+									<property name="text">
+										<string>This program is free software; you can redistribute it and/or modify it
+											under the terms of the GNU General Public License as published by the Free
+											Software Foundation; either version 2 of the License, or (at your option)
+											any later version.
+											This program is distributed in the hope that it will be useful, but WITHOUT
+											ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+											FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+											more details.</string>
+									</property>
+									<property name="wordWrap">
+										<bool>true</bool>
+									</property>
+								</widget>
+							</item>
+						</layout>
+					</widget>
+				</widget>
+			</item>
+		</layout>
+	</widget>
+	<resources />
+	<connections />
 </ui>

--- a/settings.ui
+++ b/settings.ui
@@ -1,1016 +1,1016 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-	<class>Dialog</class>
-	<widget class="QDialog" name="Dialog">
-		<property name="windowModality">
-			<enum>Qt::WindowModal</enum>
-		</property>
-		<property name="geometry">
-			<rect>
-				<x>0</x>
-				<y>0</y>
-				<width>660</width>
-				<height>352</height>
-			</rect>
-		</property>
-		<property name="windowTitle">
-			<string>Settings</string>
-		</property>
-		<property name="modal">
-			<bool>true</bool>
-		</property>
-		<layout class="QHBoxLayout" name="horizontalLayout">
-			<item>
-				<widget class="QTabWidget" name="tabWidget">
-					<property name="enabled">
-						<bool>true</bool>
-					</property>
-					<property name="currentIndex">
-						<number>0</number>
-					</property>
-					<widget class="QWidget" name="generalTab">
-						<attribute name="title">
-							<string>General</string>
-						</attribute>
-						<layout class="QVBoxLayout" name="verticalLayout">
-							<item>
-								<widget class="QGroupBox" name="groupBox_8">
-									<property name="title">
-										<string>XQEMU</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_15">
-										<item>
-											<layout class="QHBoxLayout" name="horizontalLayout_4">
-												<item>
-													<widget class="QLabel" name="label_12">
-														<property name="text">
-															<string>XQEMU Executable:</string>
-														</property>
-													</widget>
-												</item>
-												<item>
-													<widget class="QLineEdit" name="xqemuPath" />
-												</item>
-												<item>
-													<widget class="QPushButton" name="setXqemuPath">
-														<property name="text">
-															<string>Choose...</string>
-														</property>
-													</widget>
-												</item>
-											</layout>
-										</item>
-										<item>
-											<widget class="QCheckBox" name="useAccelerator">
-												<property name="text">
-													<string>Use hardware CPU acceleration</string>
-												</property>
-											</widget>
-										</item>
-									</layout>
-								</widget>
-							</item>
-							<item>
-								<widget class="QGroupBox" name="bootOptionsGroup">
-									<property name="title">
-										<string>Boot Options</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_7">
-										<item>
-											<widget class="QCheckBox" name="useShortBootAnim">
-												<property name="text">
-													<string>Use short boot animation sequence</string>
-												</property>
-											</widget>
-										</item>
-									</layout>
-								</widget>
-							</item>
-							<item>
-								<widget class="QGroupBox" name="dvdDriveGroup">
-									<property name="title">
-										<string>ISO Folder</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_5">
-										<item>
-											<layout class="QGridLayout" name="gridLayout_5">
-												<item row="0" column="1">
-													<widget class="QLineEdit" name="isoPath">
-														<property name="readOnly">
-															<bool>false</bool>
-														</property>
-													</widget>
-												</item>
-												<item row="0" column="0">
-													<widget class="QLabel" name="label_9">
-														<property name="text">
-															<string>ISO Folder:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="0" column="2">
-													<widget class="QPushButton" name="setIsoPath">
-														<property name="text">
-															<string>Choose...</string>
-														</property>
-														<property name="checkable">
-															<bool>false</bool>
-														</property>
-													</widget>
-												</item>
-											</layout>
-										</item>
-									</layout>
-								</widget>
-							</item>
-							<item>
-								<spacer name="verticalSpacer">
-									<property name="orientation">
-										<enum>Qt::Vertical</enum>
-									</property>
-									<property name="sizeHint" stdset="0">
-										<size>
-											<width>20</width>
-											<height>40</height>
-										</size>
-									</property>
-								</spacer>
-							</item>
-						</layout>
-					</widget>
-					<widget class="QWidget" name="systemTab">
-						<attribute name="title">
-							<string>System</string>
-						</attribute>
-						<layout class="QVBoxLayout" name="verticalLayout_4">
-							<item>
-								<widget class="QGroupBox" name="groupBox">
-									<property name="title">
-										<string>Firmware</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_2">
-										<item>
-											<layout class="QGridLayout" name="gridLayout">
-												<item row="1" column="0">
-													<widget class="QLabel" name="label_2">
-														<property name="text">
-															<string>Flash Image:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="0" column="1">
-													<widget class="QLineEdit" name="mcpxPath">
-														<property name="readOnly">
-															<bool>false</bool>
-														</property>
-													</widget>
-												</item>
-												<item row="1" column="1">
-													<widget class="QLineEdit" name="flashPath">
-														<property name="readOnly">
-															<bool>false</bool>
-														</property>
-													</widget>
-												</item>
-												<item row="0" column="0">
-													<widget class="QLabel" name="label">
-														<property name="text">
-															<string>MCPX ROM Image:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="1" column="2">
-													<widget class="QPushButton" name="setFlashPath">
-														<property name="text">
-															<string>Choose...</string>
-														</property>
-													</widget>
-												</item>
-												<item row="0" column="2">
-													<widget class="QPushButton" name="setMcpxPath">
-														<property name="text">
-															<string>Choose...</string>
-														</property>
-													</widget>
-												</item>
-											</layout>
-										</item>
-									</layout>
-								</widget>
-							</item>
-							<item>
-								<widget class="QGroupBox" name="groupBox_2">
-									<property name="title">
-										<string>Hard Disk</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_3">
-										<item>
-											<layout class="QGridLayout" name="gridLayout_4">
-												<item row="0" column="1">
-													<widget class="QLineEdit" name="hddPath">
-														<property name="readOnly">
-															<bool>false</bool>
-														</property>
-													</widget>
-												</item>
-												<item row="0" column="0">
-													<widget class="QLabel" name="label_8">
-														<property name="text">
-															<string>HDD Image:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="0" column="2">
-													<widget class="QPushButton" name="setHddPath">
-														<property name="text">
-															<string>Choose...</string>
-														</property>
-													</widget>
-												</item>
-											</layout>
-										</item>
-										<item>
-											<widget class="QCheckBox" name="hddLocked">
-												<property name="text">
-													<string>Locked</string>
-												</property>
-											</widget>
-										</item>
-									</layout>
-								</widget>
-							</item>
-							<item>
-								<widget class="QGroupBox" name="groupBox_4">
-									<property name="title">
-										<string>Memory</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_6">
-										<item>
-											<layout class="QHBoxLayout" name="horizontalLayout_2">
-												<item>
-													<widget class="QLabel" name="label_3">
-														<property name="text">
-															<string>Installed System Memory:</string>
-														</property>
-													</widget>
-												</item>
-												<item>
-													<widget class="QComboBox" name="systemMemory">
-														<item>
-															<property name="text">
-																<string>64 MiB</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>128 MiB</string>
-															</property>
-														</item>
-													</widget>
-												</item>
-											</layout>
-										</item>
-									</layout>
-								</widget>
-							</item>
-							<item>
-								<spacer name="verticalSpacer_2">
-									<property name="orientation">
-										<enum>Qt::Vertical</enum>
-									</property>
-									<property name="sizeHint" stdset="0">
-										<size>
-											<width>20</width>
-											<height>40</height>
-										</size>
-									</property>
-								</spacer>
-							</item>
-						</layout>
-					</widget>
-					<widget class="QWidget" name="networkTab">
-						<attribute name="title">
-							<string>Network</string>
-						</attribute>
-						<layout class="QVBoxLayout" name="verticalLayout_12">
-							<item>
-								<widget class="QGroupBox" name="groupBox_3">
-									<property name="title">
-										<string>Hardware</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_13">
-										<item>
-											<widget class="QCheckBox" name="checkBox_2">
-												<property name="text">
-													<string>Cable Connected</string>
-												</property>
-											</widget>
-										</item>
-										<item>
-											<layout class="QGridLayout" name="gridLayout_2">
-												<item row="0" column="0">
-													<widget class="QLabel" name="label_11">
-														<property name="text">
-															<string>Attached To:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="3" column="0">
-													<widget class="QLabel" name="label_10">
-														<property name="text">
-															<string>MAC Address:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="0" column="1">
-													<widget class="QComboBox" name="comboBox_2" />
-												</item>
-												<item row="3" column="1">
-													<widget class="QLineEdit" name="lineEdit" />
-												</item>
-											</layout>
-										</item>
-									</layout>
-								</widget>
-							</item>
-							<item>
-								<widget class="QGroupBox" name="groupBox_6">
-									<property name="title">
-										<string>Port Forwarding</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_14">
-										<item>
-											<widget class="QTableWidget" name="tableWidget">
-												<column>
-													<property name="text">
-														<string>Name</string>
-													</property>
-												</column>
-												<column>
-													<property name="text">
-														<string>Protocol</string>
-													</property>
-												</column>
-												<column>
-													<property name="text">
-														<string>Host Port</string>
-													</property>
-												</column>
-												<column>
-													<property name="text">
-														<string>Guest Port</string>
-													</property>
-												</column>
-											</widget>
-										</item>
-									</layout>
-								</widget>
-							</item>
-						</layout>
-					</widget>
-					<widget class="QWidget" name="inputTab">
-						<attribute name="title">
-							<string>Input Devices</string>
-						</attribute>
-						<layout class="QGridLayout" name="gridLayout_8">
-							<item row="0" column="1">
-								<widget class="QGroupBox" name="controller2Box">
-									<property name="title">
-										<string>Port 2</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_17">
-										<item>
-											<layout class="QGridLayout" name="gridLayout_9">
-												<item row="0" column="0">
-													<widget class="QLabel" name="label_14">
-														<property name="text">
-															<string>Controller:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="1" column="1">
-													<layout class="QHBoxLayout" name="horizontalLayout_10">
-														<item>
-															<widget class="QLineEdit" name="xmu2APath" />
-														</item>
-														<item>
-															<widget class="QPushButton" name="setXmu2A">
-																<property name="text">
-																	<string>Choose...</string>
-																</property>
-															</widget>
-														</item>
-													</layout>
-												</item>
-												<item row="2" column="1">
-													<layout class="QHBoxLayout" name="horizontalLayout_12">
-														<item>
-															<widget class="QLineEdit" name="xmu2BPath" />
-														</item>
-														<item>
-															<widget class="QPushButton" name="setXmu2B">
-																<property name="text">
-																	<string>Choose...</string>
-																</property>
-															</widget>
-														</item>
-													</layout>
-												</item>
-												<item row="1" column="0">
-													<widget class="QLabel" name="label_19">
-														<property name="text">
-															<string>Memory Unit A:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="0" column="1">
-													<widget class="QComboBox" name="controller2">
-														<property name="sizePolicy">
-															<sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-																<horstretch>0</horstretch>
-																<verstretch>0</verstretch>
-															</sizepolicy>
-														</property>
-														<item>
-															<property name="text">
-																<string>Not connected</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Keyboard</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #0</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #1</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #2</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #3</string>
-															</property>
-														</item>
-													</widget>
-												</item>
-												<item row="2" column="0">
-													<widget class="QLabel" name="label_22">
-														<property name="text">
-															<string>Memory Unit B:</string>
-														</property>
-													</widget>
-												</item>
-											</layout>
-										</item>
-									</layout>
-								</widget>
-							</item>
-							<item row="2" column="0">
-								<widget class="QGroupBox" name="controller3Box">
-									<property name="title">
-										<string>Port 3</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_18">
-										<item>
-											<layout class="QGridLayout" name="gridLayout_10">
-												<item row="0" column="0">
-													<widget class="QLabel" name="label_15">
-														<property name="text">
-															<string>Controller:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="0" column="1">
-													<widget class="QComboBox" name="controller3">
-														<property name="sizePolicy">
-															<sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-																<horstretch>0</horstretch>
-																<verstretch>0</verstretch>
-															</sizepolicy>
-														</property>
-														<item>
-															<property name="text">
-																<string>Not connected</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Keyboard</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #0</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #1</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #2</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #3</string>
-															</property>
-														</item>
-													</widget>
-												</item>
-												<item row="1" column="0">
-													<widget class="QLabel" name="label_20">
-														<property name="text">
-															<string>Memory Unit A:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="2" column="0">
-													<widget class="QLabel" name="label_23">
-														<property name="text">
-															<string>Memory Unit B:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="1" column="1">
-													<layout class="QHBoxLayout" name="horizontalLayout_13">
-														<item>
-															<widget class="QLineEdit" name="xmu3APath" />
-														</item>
-														<item>
-															<widget class="QPushButton" name="setXmu3A">
-																<property name="text">
-																	<string>Choose...</string>
-																</property>
-															</widget>
-														</item>
-													</layout>
-												</item>
-												<item row="2" column="1">
-													<layout class="QHBoxLayout" name="horizontalLayout_14">
-														<item>
-															<widget class="QLineEdit" name="xmu3BPath" />
-														</item>
-														<item>
-															<widget class="QPushButton" name="setXmu3B">
-																<property name="text">
-																	<string>Choose...</string>
-																</property>
-															</widget>
-														</item>
-													</layout>
-												</item>
-											</layout>
-										</item>
-									</layout>
-								</widget>
-							</item>
-							<item row="2" column="1">
-								<widget class="QGroupBox" name="controller4Box">
-									<property name="title">
-										<string>Port 4</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_19">
-										<item>
-											<layout class="QGridLayout" name="gridLayout_11">
-												<item row="0" column="1">
-													<widget class="QComboBox" name="controller4">
-														<property name="sizePolicy">
-															<sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-																<horstretch>0</horstretch>
-																<verstretch>0</verstretch>
-															</sizepolicy>
-														</property>
-														<item>
-															<property name="text">
-																<string>Not connected</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Keyboard</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #0</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #1</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #2</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #3</string>
-															</property>
-														</item>
-													</widget>
-												</item>
-												<item row="1" column="0">
-													<widget class="QLabel" name="label_21">
-														<property name="text">
-															<string>Memory Unit A:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="0" column="0">
-													<widget class="QLabel" name="label_16">
-														<property name="text">
-															<string>Controller:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="2" column="0">
-													<widget class="QLabel" name="label_24">
-														<property name="text">
-															<string>Memory Unit B:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="1" column="1">
-													<layout class="QHBoxLayout" name="horizontalLayout_15">
-														<item>
-															<widget class="QLineEdit" name="xmu4APath" />
-														</item>
-														<item>
-															<widget class="QPushButton" name="setXmu4A">
-																<property name="text">
-																	<string>Choose...</string>
-																</property>
-															</widget>
-														</item>
-													</layout>
-												</item>
-												<item row="2" column="1">
-													<layout class="QHBoxLayout" name="horizontalLayout_16">
-														<item>
-															<widget class="QLineEdit" name="xmu4BPath" />
-														</item>
-														<item>
-															<widget class="QPushButton" name="setXmu4B">
-																<property name="text">
-																	<string>Choose...</string>
-																</property>
-															</widget>
-														</item>
-													</layout>
-												</item>
-											</layout>
-										</item>
-									</layout>
-								</widget>
-							</item>
-							<item row="0" column="0">
-								<widget class="QGroupBox" name="controller1Box">
-									<property name="title">
-										<string>Port 1</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_16">
-										<item>
-											<layout class="QGridLayout" name="gridLayout_3">
-												<item row="0" column="0">
-													<widget class="QLabel" name="label_13">
-														<property name="text">
-															<string>Controller:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="1" column="0">
-													<widget class="QLabel" name="label_17">
-														<property name="text">
-															<string>Memory Unit A:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="0" column="1">
-													<widget class="QComboBox" name="controller1">
-														<property name="sizePolicy">
-															<sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-																<horstretch>0</horstretch>
-																<verstretch>0</verstretch>
-															</sizepolicy>
-														</property>
-														<item>
-															<property name="text">
-																<string>Not connected</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Keyboard</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #0</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #1</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #2</string>
-															</property>
-														</item>
-														<item>
-															<property name="text">
-																<string>Gamepad #3</string>
-															</property>
-														</item>
-													</widget>
-												</item>
-												<item row="2" column="0">
-													<widget class="QLabel" name="label_18">
-														<property name="text">
-															<string>Memory Unit B:</string>
-														</property>
-													</widget>
-												</item>
-												<item row="1" column="1">
-													<layout class="QHBoxLayout" name="horizontalLayout_9">
-														<item>
-															<widget class="QLineEdit" name="xmu1APath" />
-														</item>
-														<item>
-															<widget class="QPushButton" name="setXmu1A">
-																<property name="sizePolicy">
-																	<sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-																		<horstretch>0</horstretch>
-																		<verstretch>0</verstretch>
-																	</sizepolicy>
-																</property>
-																<property name="text">
-																	<string>Choose...</string>
-																</property>
-															</widget>
-														</item>
-													</layout>
-												</item>
-												<item row="2" column="1">
-													<layout class="QHBoxLayout" name="horizontalLayout_11">
-														<item>
-															<widget class="QLineEdit" name="xmu1BPath" />
-														</item>
-														<item>
-															<widget class="QPushButton" name="setXmu1B">
-																<property name="text">
-																	<string>Choose...</string>
-																</property>
-															</widget>
-														</item>
-													</layout>
-												</item>
-											</layout>
-										</item>
-									</layout>
-								</widget>
-							</item>
-						</layout>
-					</widget>
-					<widget class="QWidget" name="debugTab">
-						<attribute name="title">
-							<string>Debug</string>
-						</attribute>
-						<layout class="QVBoxLayout" name="verticalLayout_8">
-							<item>
-								<widget class="QGroupBox" name="groupBox_5">
-									<property name="enabled">
-										<bool>false</bool>
-									</property>
-									<property name="title">
-										<string>SuperIO</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_9">
-										<item>
-											<widget class="QCheckBox" name="checkBox">
-												<property name="text">
-													<string>Enable SuperIO</string>
-												</property>
-											</widget>
-										</item>
-									</layout>
-								</widget>
-							</item>
-							<item>
-								<widget class="QGroupBox" name="groupBox_7">
-									<property name="title">
-										<string>GDB Server</string>
-									</property>
-									<layout class="QVBoxLayout" name="verticalLayout_10">
-										<item>
-											<widget class="QCheckBox" name="gdbEnabled">
-												<property name="text">
-													<string>Enable GDB Server</string>
-												</property>
-											</widget>
-										</item>
-										<item>
-											<widget class="QCheckBox" name="waitForGdb">
-												<property name="text">
-													<string>Wait for connection at startup</string>
-												</property>
-											</widget>
-										</item>
-										<item>
-											<layout class="QHBoxLayout" name="horizontalLayout_3">
-												<item>
-													<widget class="QLabel" name="label_4">
-														<property name="text">
-															<string>GDB Server Port:</string>
-														</property>
-													</widget>
-												</item>
-												<item>
-													<widget class="QLineEdit" name="gdbPort">
-														<property name="maximumSize">
-															<size>
-																<width>100</width>
-																<height>16777215</height>
-															</size>
-														</property>
-														<property name="placeholderText">
-															<string>1234</string>
-														</property>
-													</widget>
-												</item>
-												<item>
-													<spacer name="horizontalSpacer">
-														<property name="orientation">
-															<enum>Qt::Horizontal</enum>
-														</property>
-														<property name="sizeHint" stdset="0">
-															<size>
-																<width>40</width>
-																<height>20</height>
-															</size>
-														</property>
-													</spacer>
-												</item>
-											</layout>
-										</item>
-									</layout>
-								</widget>
-							</item>
-							<item>
-								<spacer name="verticalSpacer_3">
-									<property name="orientation">
-										<enum>Qt::Vertical</enum>
-									</property>
-									<property name="sizeHint" stdset="0">
-										<size>
-											<width>20</width>
-											<height>40</height>
-										</size>
-									</property>
-								</spacer>
-							</item>
-						</layout>
-					</widget>
-					<widget class="QWidget" name="cliTab">
-						<attribute name="title">
-							<string>CLI</string>
-						</attribute>
-						<layout class="QVBoxLayout" name="verticalLayout_8">
-							<item>
-								<widget class="QGroupBox" name="groupBox_10">
-									<property name="title">
-										<string>Additonal arguments</string>
-									</property>
-									<layout class="QGridLayout" name="gridLayout_7">
-										<item row="0" column="0">
-											<widget class="QLineEdit" name="additionalArgs" />
-										</item>
-									</layout>
-								</widget>
-							</item>
-							<item>
-								<widget class="QGroupBox" name="groupBox_9">
-									<property name="title">
-										<string>XQEMU invocation preview</string>
-									</property>
-									<layout class="QGridLayout" name="gridLayout_6">
-										<item row="0" column="0">
-											<widget class="QPlainTextEdit" name="invocationPreview">
-												<property name="readOnly">
-													<bool>true</bool>
-												</property>
-											</widget>
-										</item>
-									</layout>
-								</widget>
-							</item>
-						</layout>
-					</widget>
-					<widget class="QWidget" name="aboutTab">
-						<attribute name="title">
-							<string>About</string>
-						</attribute>
-						<layout class="QVBoxLayout" name="verticalLayout_11">
-							<item>
-								<spacer name="verticalSpacer_5">
-									<property name="orientation">
-										<enum>Qt::Vertical</enum>
-									</property>
-									<property name="sizeHint" stdset="0">
-										<size>
-											<width>20</width>
-											<height>40</height>
-										</size>
-									</property>
-								</spacer>
-							</item>
-							<item>
-								<widget class="QLabel" name="label_5">
-									<property name="font">
-										<font>
-											<pointsize>24</pointsize>
-											<weight>75</weight>
-											<bold>true</bold>
-										</font>
-									</property>
-									<property name="text">
-										<string>xqemu manager</string>
-									</property>
-									<property name="alignment">
-										<set>Qt::AlignCenter</set>
-									</property>
-								</widget>
-							</item>
-							<item>
-								<widget class="QLabel" name="copyrightLabel">
-									<property name="text">
-										<string>Copyright (C) 2018, XQEMU Developers</string>
-									</property>
-									<property name="alignment">
-										<set>Qt::AlignCenter</set>
-									</property>
-								</widget>
-							</item>
-							<item>
-								<spacer name="verticalSpacer_4">
-									<property name="orientation">
-										<enum>Qt::Vertical</enum>
-									</property>
-									<property name="sizeHint" stdset="0">
-										<size>
-											<width>20</width>
-											<height>40</height>
-										</size>
-									</property>
-								</spacer>
-							</item>
-							<item>
-								<widget class="QLabel" name="label_6">
-									<property name="text">
-										<string>Version: 0123456789</string>
-									</property>
-								</widget>
-							</item>
-							<item>
-								<widget class="QLabel" name="label_7">
-									<property name="text">
-										<string>This program is free software; you can redistribute it and/or modify it
-											under the terms of the GNU General Public License as published by the Free
-											Software Foundation; either version 2 of the License, or (at your option)
-											any later version.
-											This program is distributed in the hope that it will be useful, but WITHOUT
-											ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-											FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-											more details.</string>
-									</property>
-									<property name="wordWrap">
-										<bool>true</bool>
-									</property>
-								</widget>
-							</item>
-						</layout>
-					</widget>
-				</widget>
-			</item>
-		</layout>
-	</widget>
-	<resources />
-	<connections />
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>660</width>
+    <height>352</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Settings</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="generalTab">
+      <attribute name="title">
+       <string>General</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QGroupBox" name="groupBox_8">
+         <property name="title">
+          <string>XQEMU</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_15">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QLabel" name="label_12">
+              <property name="text">
+               <string>XQEMU Executable:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="xqemuPath" />
+            </item>
+            <item>
+             <widget class="QPushButton" name="setXqemuPath">
+              <property name="text">
+               <string>Choose...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="useAccelerator">
+            <property name="text">
+             <string>Use hardware CPU acceleration</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="bootOptionsGroup">
+         <property name="title">
+          <string>Boot Options</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <item>
+           <widget class="QCheckBox" name="useShortBootAnim">
+            <property name="text">
+             <string>Use short boot animation sequence</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="dvdDriveGroup">
+         <property name="title">
+          <string>ISO Folder</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <layout class="QGridLayout" name="gridLayout_5">
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="isoPath">
+              <property name="readOnly">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_9">
+              <property name="text">
+               <string>ISO Folder:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QPushButton" name="setIsoPath">
+              <property name="text">
+               <string>Choose...</string>
+              </property>
+              <property name="checkable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="systemTab">
+      <attribute name="title">
+       <string>System</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Firmware</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <layout class="QGridLayout" name="gridLayout">
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>Flash Image:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="mcpxPath">
+              <property name="readOnly">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="flashPath">
+              <property name="readOnly">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>MCPX ROM Image:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QPushButton" name="setFlashPath">
+              <property name="text">
+               <string>Choose...</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QPushButton" name="setMcpxPath">
+              <property name="text">
+               <string>Choose...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="title">
+          <string>Hard Disk</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <layout class="QGridLayout" name="gridLayout_4">
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="hddPath">
+              <property name="readOnly">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_8">
+              <property name="text">
+               <string>HDD Image:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QPushButton" name="setHddPath">
+              <property name="text">
+               <string>Choose...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="hddLocked">
+            <property name="text">
+             <string>Locked</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_4">
+         <property name="title">
+          <string>Memory</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="label_3">
+              <property name="text">
+               <string>Installed System Memory:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="systemMemory">
+              <item>
+               <property name="text">
+                <string>64 MiB</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>128 MiB</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="networkTab">
+      <attribute name="title">
+       <string>Network</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_12">
+       <item>
+        <widget class="QGroupBox" name="groupBox_3">
+         <property name="title">
+          <string>Hardware</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_13">
+          <item>
+           <widget class="QCheckBox" name="checkBox_2">
+            <property name="text">
+             <string>Cable Connected</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QGridLayout" name="gridLayout_2">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_11">
+              <property name="text">
+               <string>Attached To:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_10">
+              <property name="text">
+               <string>MAC Address:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="comboBox_2" />
+            </item>
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="lineEdit" />
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_6">
+         <property name="title">
+          <string>Port Forwarding</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_14">
+          <item>
+           <widget class="QTableWidget" name="tableWidget">
+            <column>
+             <property name="text">
+              <string>Name</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Protocol</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Host Port</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Guest Port</string>
+             </property>
+            </column>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="inputTab">
+      <attribute name="title">
+       <string>Input Devices</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_8">
+       <item row="0" column="1">
+        <widget class="QGroupBox" name="controller2Box">
+         <property name="title">
+          <string>Port 2</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_17">
+          <item>
+           <layout class="QGridLayout" name="gridLayout_9">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_14">
+              <property name="text">
+               <string>Controller:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_10">
+              <item>
+               <widget class="QLineEdit" name="xmu2APath" />
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu2A">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="2" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_12">
+              <item>
+               <widget class="QLineEdit" name="xmu2BPath" />
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu2B">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_19">
+              <property name="text">
+               <string>Memory Unit A:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="controller2">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <item>
+               <property name="text">
+                <string>Not connected</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Keyboard</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #0</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #1</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #2</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #3</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_22">
+              <property name="text">
+               <string>Memory Unit B:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QGroupBox" name="controller3Box">
+         <property name="title">
+          <string>Port 3</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_18">
+          <item>
+           <layout class="QGridLayout" name="gridLayout_10">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_15">
+              <property name="text">
+               <string>Controller:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="controller3">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <item>
+               <property name="text">
+                <string>Not connected</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Keyboard</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #0</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #1</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #2</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #3</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_20">
+              <property name="text">
+               <string>Memory Unit A:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_23">
+              <property name="text">
+               <string>Memory Unit B:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_13">
+              <item>
+               <widget class="QLineEdit" name="xmu3APath" />
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu3A">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="2" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_14">
+              <item>
+               <widget class="QLineEdit" name="xmu3BPath" />
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu3B">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QGroupBox" name="controller4Box">
+         <property name="title">
+          <string>Port 4</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_19">
+          <item>
+           <layout class="QGridLayout" name="gridLayout_11">
+            <item row="0" column="1">
+             <widget class="QComboBox" name="controller4">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <item>
+               <property name="text">
+                <string>Not connected</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Keyboard</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #0</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #1</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #2</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #3</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_21">
+              <property name="text">
+               <string>Memory Unit A:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_16">
+              <property name="text">
+               <string>Controller:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_24">
+              <property name="text">
+               <string>Memory Unit B:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_15">
+              <item>
+               <widget class="QLineEdit" name="xmu4APath" />
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu4A">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="2" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_16">
+              <item>
+               <widget class="QLineEdit" name="xmu4BPath" />
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu4B">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QGroupBox" name="controller1Box">
+         <property name="title">
+          <string>Port 1</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_16">
+          <item>
+           <layout class="QGridLayout" name="gridLayout_3">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_13">
+              <property name="text">
+               <string>Controller:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_17">
+              <property name="text">
+               <string>Memory Unit A:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="controller1">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <item>
+               <property name="text">
+                <string>Not connected</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Keyboard</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #0</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #1</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #2</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Gamepad #3</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_18">
+              <property name="text">
+               <string>Memory Unit B:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_9">
+              <item>
+               <widget class="QLineEdit" name="xmu1APath" />
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu1A">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="2" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_11">
+              <item>
+               <widget class="QLineEdit" name="xmu1BPath" />
+              </item>
+              <item>
+               <widget class="QPushButton" name="setXmu1B">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="debugTab">
+      <attribute name="title">
+       <string>Debug</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_8">
+       <item>
+        <widget class="QGroupBox" name="groupBox_5">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="title">
+          <string>SuperIO</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_9">
+          <item>
+           <widget class="QCheckBox" name="checkBox">
+            <property name="text">
+             <string>Enable SuperIO</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_7">
+         <property name="title">
+          <string>GDB Server</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_10">
+          <item>
+           <widget class="QCheckBox" name="gdbEnabled">
+            <property name="text">
+             <string>Enable GDB Server</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="waitForGdb">
+            <property name="text">
+             <string>Wait for connection at startup</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QLabel" name="label_4">
+              <property name="text">
+               <string>GDB Server Port:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="gdbPort">
+              <property name="maximumSize">
+               <size>
+                <width>100</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="placeholderText">
+               <string>1234</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="cliTab">
+      <attribute name="title">
+       <string>CLI</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_8">
+       <item>
+        <widget class="QGroupBox" name="groupBox_10">
+         <property name="title">
+          <string>Additonal arguments</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_7">
+          <item row="0" column="0">
+           <widget class="QLineEdit" name="additionalArgs" />
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_9">
+         <property name="title">
+          <string>XQEMU invocation preview</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_6">
+          <item row="0" column="0">
+           <widget class="QPlainTextEdit" name="invocationPreview">
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="aboutTab">
+      <attribute name="title">
+       <string>About</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_11">
+       <item>
+        <spacer name="verticalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_5">
+         <property name="font">
+          <font>
+           <pointsize>24</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>xqemu manager</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="copyrightLabel">
+         <property name="text">
+          <string>Copyright (C) 2018, XQEMU Developers</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>Version: 0123456789</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>This program is free software; you can redistribute it and/or modify it
+           under the terms of the GNU General Public License as published by the Free
+           Software Foundation; either version 2 of the License, or (at your option)
+           any later version.
+           This program is distributed in the hope that it will be useful, but WITHOUT
+           ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+           FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+           more details.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources />
+ <connections />
 </ui>


### PR DESCRIPTION
New stuff:
- Game library in main window
- Moved the `Start`, `Pause`, `Restart` and `Screenshot` button to a menu bar item called `Emulator`
- Some plastic surgery on the UI files cause tabs are better than spaces
