### PR TITLE
Use stylized "XQEMU-Manager" name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xqemu Manager Prototype
+# XQEMU-Manager Prototype
 
 | Windows Build Status |
 | -------------------- |

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>XQEMU Manager</string>
+   <string>XQEMU-Manager</string>
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">

--- a/settings.ui
+++ b/settings.ui
@@ -958,7 +958,7 @@
           </font>
          </property>
          <property name="text">
-          <string>xqemu manager</string>
+          <string>XQEMU-Manager</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>


### PR DESCRIPTION
We have been using "XQEMU" instead of "xqemu" or "Xqemu" for a while.

Also the repository name is "xqemu-manager" for technical reasons (dash instead of a space), but the dash became part of the name. It helps to differentiate "xqemu *words*" and "xqemu-manager" in written conversations.

I've renamed all instances in this repository to "XQEMU-Manager".