### PR TITLE
Work around "PyInstaller" installation failure on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,8 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "python -m pip install --upgrade pip"
+  # Disabled because it broke PyInstaller installation on AppVeyor.
+  #- "python -m pip install --upgrade pip"
 
   # Install the build dependencies of the project. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,


### PR DESCRIPTION
As of recently, upgrading pip seems to break PyInstaller installation on AppVeyor. This therefore disables it.