### PR TITLE
Ensure badge + link only points to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 | Windows Build Status |
 | -------------------- |
-| [![Build status](https://ci.appveyor.com/api/projects/status/9hb88yawy54b0086?svg=true)](https://ci.appveyor.com/project/xqemu-bot/xqemu-manager) |
+| [![Build status](https://ci.appveyor.com/api/projects/status/9hb88yawy54b0086/branch/master?svg=true)](https://ci.appveyor.com/project/xqemu-bot/xqemu-manager?branch=master) |
+| [Latest Build](https://ci.appveyor.com/api/projects/xqemu-bot/xqemu-manager/artifacts/xqemu-manager.zip?branch=master) |
 
 This is a helper GUI prototype (hastily hacked together) to launch and control
 [XQEMU](http://github.com/xqemu/xqemu), currently in very early stages. Pull


### PR DESCRIPTION
Quick change so users download the latest build from `master`. Prevents people from thinking the project is broken thanks to bad PR's, and ensures only accepted changes get shipped to people as binaries.

Also adds a clearer link to the latest artifact from the master branch.

Closes #45 