### PR TITLE
Use QProcess instead of subprocess, add log area

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -44,17 +44,21 @@
      </widget>
     </item>
     <item>
-     <spacer name="verticalSpacer">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>XQEMU Messages:</string>
       </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>20</width>
-        <height>40</height>
-       </size>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPlainTextEdit" name="log">
+      <property name="undoRedoEnabled">
+       <bool>false</bool>
       </property>
-     </spacer>
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+     </widget>
     </item>
    </layout>
   </widget>


### PR DESCRIPTION
This has been lying around for a while. It adds a log area where xqemu output is displayed, a message that is displayed if xqemu quits with a non-zero return value, and generally improves keeping track of the subprocess.

/edit:

Screenshot after starting & stopping xqemu:
![Screenshot_20191002_015005](https://user-images.githubusercontent.com/1339483/66008679-ba76b280-e4b7-11e9-8930-5018a6ffac5c.png)

Screenshot after xqemu exiting with a non-zero return value (note that the Start/Stop button was updated correctly when xqemu quit):
![Screenshot_20191002_015316](https://user-images.githubusercontent.com/1339483/66008716-e1cd7f80-e4b7-11e9-8c99-c3c7a80f2408.png)
