### PR TITLE
Add path for EEPROM

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ class SettingsManager(object):
 			'xqemu_path': '/path/to/xqemu',
 			'mcpx_path': '/path/to/mcpx.bin',
 			'flash_path': '/path/to/flash.bin',
+			'eeprom_path': '/path/to/eeprom.bin',
 			'hdd_path': '/path/to/hdd.img',
 			'hdd_locked': True,
 			'dvd_present': True,
@@ -115,6 +116,8 @@ class SettingsWindow(QDialog, settings_class):
 		bindFilePicker(self.setMcpxPath, self.mcpxPath)
 		bindTextWidget(self.flashPath, 'flash_path')
 		bindFilePicker(self.setFlashPath, self.flashPath)
+		bindTextWidget(self.eepromPath, 'eeprom_path')
+		bindFilePicker(self.browseEepromPath, self.eepromPath)
 		bindTextWidget(self.hddPath, 'hdd_path')
 		bindFilePicker(self.setHddPath, self.hddPath)
 		bindCheckWidget(self.hddLocked, 'hdd_locked')
@@ -229,6 +232,9 @@ class Xqemu(object):
 		flash_path = settings.settings['flash_path']
 		check_path(flash_path)
 		flash_path_arg = escape_path(flash_path)
+		eeprom_path = settings.settings['eeprom_path']
+		check_path(eeprom_path)
+		eeprom_path_arg = escape_path(eeprom_path)
 		hdd_path = settings.settings['hdd_path']
 		check_path(hdd_path)
 		hdd_path_arg = escape_path(hdd_path)
@@ -246,7 +252,7 @@ class Xqemu(object):
 		# Build qemu launch cmd
 		cmd = [xqemu_path,
 		       '-cpu','pentium3',
-		       '-machine','xbox%(accel_arg)s,bootrom=%(mcpx_path_arg)s%(short_anim_arg)s' % locals(),
+		       '-machine', 'xbox%(accel_arg)s,bootrom=%(mcpx_path_arg)s,eeprom=%(eeprom_path_arg)s%(short_anim_arg)s' % locals(),
 		       '-m', '%(sys_memory)s' % locals(),
 		       '-bios', '%(flash_path_arg)s' % locals(),
 		       '-drive','file=%(hdd_path_arg)s,index=0,media=disk%(hdd_lock_arg)s' % locals(),

--- a/settings.ui
+++ b/settings.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>660</width>
-    <height>352</height>
+    <height>385</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -201,6 +201,39 @@
              </widget>
             </item>
            </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="eepromGroupBox">
+         <property name="title">
+          <string>EEPROM</string>
+         </property>
+         <layout class="QGridLayout" name="eepromGridLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="eepromPathLabel">
+            <property name="text">
+             <string>EEPROM Image:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="eepromPath"/>
+          </item>
+          <item row="0" column="2">
+           <widget class="QPushButton" name="browseEepromPath">
+            <property name="text">
+             <string>Choose...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="eepromWritebackLabel">
+            <property name="text">
+             <string>EEPROM writeback is not currently supported. Changes to EEPROM will not be saved!</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
This PR adds a path to your EEPROM in settings. Currently this design forces a user to choose their own EEPROM and will not launch without it. It was discussed on discord that maybe XQEMU should ship with a dummy EEPROM in the future.

Below is a screenshot of the added option, please discuss if something does not look suitable.

This closes #43 

![image](https://user-images.githubusercontent.com/4371017/66961897-4d295c80-f035-11e9-8326-88af273bf1d9.png)
