### PR TITLE
Fix multiple settings dialog

### DIFF
--- a/main.py
+++ b/main.py
@@ -438,6 +438,12 @@ class MainWindow(QMainWindow, mainwindow_class):
 
 	def onExitClicked(self):
 		self.inst.stop()
+		self.settings_window.close()
+		sys.exit(0)
+
+	def closeEvent(self,event):
+		self.inst.stop()
+		self.settings_window.close()
 		sys.exit(0)
 
 def main():

--- a/main.py
+++ b/main.py
@@ -353,6 +353,7 @@ class MainWindow(QMainWindow, mainwindow_class):
 		self.inst = Xqemu()
 		self.settings = SettingsManager()
 		self.settings.load()
+		self.settings_window = SettingsWindow(self.settings)
 		self.runButton.setText('Start')
 		self.pauseButton.setText('Pause')
 		self.pauseButton.setEnabled(False)
@@ -429,8 +430,10 @@ class MainWindow(QMainWindow, mainwindow_class):
 		self.inst.restart()
 
 	def onSettingsClicked(self):
-		s = SettingsWindow(self.settings)
-		s.exec_()
+		if not self.settings_window.isVisible():
+			self.settings_window.exec_()
+		else:
+			self.settings_window.setFocus()
 		self.settings.save()
 
 	def onExitClicked(self):

--- a/main.py
+++ b/main.py
@@ -433,7 +433,7 @@ class MainWindow(QMainWindow, mainwindow_class):
 		if not self.settings_window.isVisible():
 			self.settings_window.exec_()
 		else:
-			self.settings_window.setFocus()
+			self.settings_window.raise_()
 		self.settings.save()
 
 	def onExitClicked(self):


### PR DESCRIPTION
This pull request aims to close issue #59. To get the desired behavior, I made the settings window a member of the MainWindow class. Then I simply check if the dialog is already visible before calling exec_(). Something else I added is that if the settings dialog is already open and the user clicks Edit->Settings, the settings window is brought to the front by calling the raise_() function.

This pull request also fixes the issue that I mentioned in my comment on #59. So, closing the xqemu-manager now also closes the settings window. I accomplished this by adding a closeEvent method to the MainWindow class. I think this should of been there from the beginning. The onExitClicked code is only called from the File->Exit button and not when the window is closed. 

A downside to closing the settings window when the main window is closed is that currently the code doesn't save your settings before closing the window. So, the user's settings could be lost. I think this can be fixed with issue #15. Maybe we can detect if the settings have changed without being saved then on exit ask the user if they would like to save them before closing.

Please reply if I've done anything wrong or if this should be split up into two separate issues.

